### PR TITLE
introduce ZyteAPITextResponse and ZyteAPIResponse to store raw Zyte Data API Response

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,8 +6,8 @@ TBD
 
 * Introduce ``ZyteAPIResponse`` and ``ZyteAPITextResponse`` which are subclasses
   of ``scrapy.http.Response`` and ``scrapy.http.TextResponse`` respectively.
-  These new response classes hold the raw Zyte Data API response in its
-  ``zyte_api`` attribute.
+  These new response classes hold the raw Zyte Data API response in the
+  ``raw_api_response`` attribute.
 
 0.1.0 (2022-02-03)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ TBD
 * Introduce ``ZyteAPIResponse`` and ``ZyteAPITextResponse`` which are subclasses
   of ``scrapy.http.Response`` and ``scrapy.http.TextResponse`` respectively.
   These new response classes hold the raw Zyte API response in its
-  ``zyte_api_response`` attribute.
+  ``zyte_api`` attribute.
 
 0.1.0 (2022-02-03)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Changes
 =======
 
+TBD
+---
+
+* Introduce ``ZyteAPIResponse`` and ``ZyteAPITextResponse`` which are subclasses
+  of ``scrapy.http.Response`` and ``scrapy.http.TextResponse`` respectively.
+  These new response classes hold the raw Zyte API response in its
+  ``zyte_api_response`` attribute.
+
 0.1.0 (2022-02-03)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ TBD
 
 * Introduce ``ZyteAPIResponse`` and ``ZyteAPITextResponse`` which are subclasses
   of ``scrapy.http.Response`` and ``scrapy.http.TextResponse`` respectively.
-  These new response classes hold the raw Zyte API response in its
+  These new response classes hold the raw Zyte Data API response in its
   ``zyte_api`` attribute.
 
 0.1.0 (2022-02-03)

--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,7 @@ key to download a request using Zyte API. Full list of parameters is provided in
         def parse(self, response):
             yield {"URL": response.url, "status": response.status, "HTML": response.body}
 
-            print(response.zyte_api_response)
+            print(response.zyte_api)
             # {
             #     'url': 'https://quotes.toscrape.com/',
             #     'browserHtml': '<html> ... </html>',
@@ -113,7 +113,7 @@ key to download a request using Zyte API. Full list of parameters is provided in
             #     'download_slot': 'quotes.toscrape.com'
             # }
 
-The raw Zyte API Response can be accessed via the ``zyte_api_response`` attribute
+The raw Zyte API Response can be accessed via the ``zyte_api`` attribute
 of the response object. Note that such responses are of ``ZyteAPIResponse`` and
 ``ZyteAPITextResponse`` which are respectively subclasses of ``scrapy.http.Response``
 and ``scrapy.http.TextResponse``. Such classes are needed to hold the raw Zyte API

--- a/README.rst
+++ b/README.rst
@@ -99,7 +99,6 @@ key to download a request using Zyte API. Full list of parameters is provided in
             #     'url': 'https://quotes.toscrape.com/',
             #     'browserHtml': '<html> ... </html>',
             #     'echoData': {'some_value_I_could_track': 123},
-            #     'actions': []
             # }
 
             print(response.request.meta)

--- a/README.rst
+++ b/README.rst
@@ -63,8 +63,12 @@ Here's an example of the things needed inside a Scrapy project's ``settings.py``
 Usage
 -----
 
-To enable every request to be sent through Zyte API, you can set the following
-in the ``settings.py`` file or `any other settings within Scrapy
+To enable a ``scrapy.Request`` to go through Zyte Data API, the ``zyte_api`` key in
+`Request.meta <https://docs.scrapy.org/en/latest/topics/request-response.html#scrapy.http.Request.meta>`_
+must be present and has dict-like contents.
+
+To set the default parameters for Zyte API enabled requests, you can set the
+following in the ``settings.py`` file or `any other settings within Scrapy
 <https://docs.scrapy.org/en/latest/topics/settings.html#populating-the-settings>`_:
 
 .. code-block:: python
@@ -74,12 +78,12 @@ in the ``settings.py`` file or `any other settings within Scrapy
         "geolocation": "US",
     }
 
-You can see the full list of parameters in the `Zyte API Specification
+You can see the full list of parameters in the `Zyte Data API Specification
 <https://docs.zyte.com/zyte-api/openapi.html#zyte-openapi-spec>`_.
 
-On the other hand, you could also control it on a per-request basis by setting the
-``zyte_api`` key in `Request.meta <https://docs.scrapy.org/en/latest/topics/request-response.html#scrapy.http.Request.meta>`_.
-When doing so, it will override any parameters set in the 
+Note that the ``ZYTE_API_DEFAULT_PARAMS`` would only work if the ``zyte_api``
+key in `Request.meta <https://docs.scrapy.org/en/latest/topics/request-response.html#scrapy.http.Request.meta>`_
+is set. When doing so, it will override any parameters set in the 
 ``ZYTE_API_DEFAULT_PARAMS`` setting.
 
 .. code-block:: python
@@ -90,15 +94,19 @@ When doing so, it will override any parameters set in the
     class SampleQuotesSpider(scrapy.Spider):
         name = "sample_quotes"
 
-        def start_requests(self):
+        custom_settings = {
+            "ZYTE_API_DEFAULT_PARAMS": {
+                "geolocation": "US",  # You can set any Geolocation region you want.
+            }
+        }
 
+        def start_requests(self):
             yield scrapy.Request(
                 url="http://books.toscrape.com/",
                 callback=self.parse,
                 meta={
                     "zyte_api": {
                         "browserHtml": True,
-                        "geolocation": "US",  # You can set any Geolocation region you want.
                         "javascript": True,
                         "echoData": {"some_value_I_could_track": 123},
                     }

--- a/README.rst
+++ b/README.rst
@@ -33,8 +33,8 @@ Installation
 
 This package requires Python 3.7+.
 
-How to configure
-----------------
+Configuration
+-------------
 
 Replace the default ``http`` and ``https`` in Scrapy's
 `DOWNLOAD_HANDLERS <https://docs.scrapy.org/en/latest/topics/settings.html#std-setting-DOWNLOAD_HANDLERS>`_
@@ -60,8 +60,8 @@ Here's example of the things needed inside a Scrapy project's ``settings.py`` fi
 
     TWISTED_REACTOR = "twisted.internet.asyncioreactor.AsyncioSelectorReactor"
 
-How to use
-----------
+Usage
+-----
 
 Set the ``zyte_api`` `Request.meta
 <https://docs.scrapy.org/en/latest/topics/request-response.html#scrapy.http.Request.meta>`_
@@ -70,27 +70,52 @@ key to download a request using Zyte API. Full list of parameters is provided in
 
 .. code-block:: python
 
-   import scrapy
+    import scrapy
 
 
-   class TestSpider(scrapy.Spider):
-       name = "test"
+    class SampleQuotesSpider(scrapy.Spider):
+        name = "sample_quotes"
 
-       def start_requests(self):
+        def start_requests(self):
 
-           yield scrapy.Request(
-               url="http://books.toscrape.com/",
-               callback=self.parse,
-               meta={
-                   "zyte_api": {
-                       "browserHtml": True,
-                       # You can set any GEOLocation region you want.
-                       "geolocation": "US",
-                       "javascript": True,
-                       "echoData": {"something": True},
-                   }
-               },
-           )
+            yield scrapy.Request(
+                url="http://books.toscrape.com/",
+                callback=self.parse,
+                meta={
+                    "zyte_api": {
+                        "browserHtml": True,
+                        "geolocation": "US",  # You can set any Geolocation region you want.
+                        "javascript": True,
+                        "echoData": {"some_value_I_could_track": 123},
+                    }
+                },
+            )
 
-       def parse(self, response):
-           yield {"URL": response.url, "status": response.status, "HTML": response.body}
+        def parse(self, response):
+            yield {"URL": response.url, "status": response.status, "HTML": response.body}
+
+            print(response.zyte_api_response)
+            # {
+            #     'url': 'https://quotes.toscrape.com/',
+            #     'browserHtml': '<html> ... </html>',
+            #     'echoData': {'some_value_I_could_track': 123},
+            #     'actions': []
+            # }
+
+            print(response.request.meta)
+            # {
+            #     'zyte_api': {
+            #         'browserHtml': True,
+            #         'geolocation': 'US',
+            #         'javascript': True,
+            #         'echoData': {'some_value_I_could_track': 123}
+            #     },
+            #     'download_timeout': 180.0,
+            #     'download_slot': 'quotes.toscrape.com'
+            # }
+
+The raw Zyte API Response can be accessed via the ``zyte_api_response`` attribute
+of the response object. Note that such responses are of ``ZyteAPIResponse`` and
+``ZyteAPITextResponse`` which are respectively subclasses of ``scrapy.http.Response``
+and ``scrapy.http.TextResponse``. Such classes are needed to hold the raw Zyte API
+responses.

--- a/README.rst
+++ b/README.rst
@@ -77,9 +77,9 @@ in the ``settings.py`` file or `any other settings within Scrapy
 You can see the full list of parameters in the `Zyte API Specification
 <https://docs.zyte.com/zyte-api/openapi.html#zyte-openapi-spec>`_.
 
-On the other hand, you could also control it on a per request basis by setting the
+On the other hand, you could also control it on a per-request basis by setting the
 ``zyte_api`` key in `Request.meta <https://docs.scrapy.org/en/latest/topics/request-response.html#scrapy.http.Request.meta>`_.
-When doing so, it will override any parameters that was set in the 
+When doing so, it will override any parameters set in the 
 ``ZYTE_API_DEFAULT_PARAMS`` setting.
 
 .. code-block:: python
@@ -127,8 +127,8 @@ When doing so, it will override any parameters that was set in the
             #     'download_slot': 'quotes.toscrape.com'
             # }
 
-The raw Zyte API Response can be accessed via the ``zyte_api`` attribute
+The raw Zyte Data API response can be accessed via the ``zyte_api`` attribute
 of the response object. Note that such responses are of ``ZyteAPIResponse`` and
-``ZyteAPITextResponse`` which are respectively subclasses of ``scrapy.http.Response``
-and ``scrapy.http.TextResponse``. Such classes are needed to hold the raw Zyte API
+``ZyteAPITextResponse`` types, which are respectively subclasses of ``scrapy.http.Response``
+and ``scrapy.http.TextResponse``. Such classes are needed to hold the raw Zyte Data API
 responses.

--- a/README.rst
+++ b/README.rst
@@ -116,7 +116,7 @@ is set. When doing so, it will override any parameters set in the
         def parse(self, response):
             yield {"URL": response.url, "status": response.status, "HTML": response.body}
 
-            print(response.zyte_api)
+            print(response.raw_api_response)
             # {
             #     'url': 'https://quotes.toscrape.com/',
             #     'browserHtml': '<html> ... </html>',
@@ -135,7 +135,7 @@ is set. When doing so, it will override any parameters set in the
             #     'download_slot': 'quotes.toscrape.com'
             # }
 
-The raw Zyte Data API response can be accessed via the ``zyte_api`` attribute
+The raw Zyte Data API response can be accessed via the ``raw_api_response`` attribute
 of the response object. Note that such responses are of ``ZyteAPIResponse`` and
 ``ZyteAPITextResponse`` types, which are respectively subclasses of ``scrapy.http.Response``
 and ``scrapy.http.TextResponse``. Such classes are needed to hold the raw Zyte Data API

--- a/scrapy_zyte_api/handler.py
+++ b/scrapy_zyte_api/handler.py
@@ -15,7 +15,7 @@ from twisted.internet.defer import Deferred, inlineCallbacks
 from zyte_api.aio.client import AsyncClient, create_session
 from zyte_api.aio.errors import RequestError
 
-from .responses import ZyteAPIResponse, ZyteAPITextResponse, process_response
+from .responses import ZyteAPIResponse, ZyteAPITextResponse, _process_response
 
 logger = logging.getLogger(__name__)
 
@@ -88,7 +88,7 @@ class ScrapyZyteAPIDownloadHandler(HTTPDownloadHandler):
             raise IgnoreRequest()
 
         self._stats.inc_value("scrapy-zyte-api/request_count")
-        return process_response(api_response, request)
+        return _process_response(api_response, request)
 
     @inlineCallbacks
     def close(self) -> Generator:

--- a/scrapy_zyte_api/handler.py
+++ b/scrapy_zyte_api/handler.py
@@ -32,7 +32,6 @@ class ScrapyZyteAPIDownloadHandler(HTTPDownloadHandler):
         self._stats = crawler.stats
         self._job_id = crawler.settings.get("JOB")
         self._session = create_session()
-        self._encoding = "utf-8"
 
     @classmethod
     def from_crawler(cls, crawler):
@@ -89,9 +88,7 @@ class ScrapyZyteAPIDownloadHandler(HTTPDownloadHandler):
         if api_response.get("browserHtml"):
             # Using TextResponse because browserHtml always returns a browser-rendered page
             # even when requesting files (like images)
-            return ZyteAPITextResponse.from_api_response(
-                api_response, request=request, encoding=self._encoding
-            )
+            return ZyteAPITextResponse.from_api_response(api_response, request=request)
         else:
             return ZyteAPIResponse.from_api_response(api_response, request=request)
 

--- a/scrapy_zyte_api/responses.py
+++ b/scrapy_zyte_api/responses.py
@@ -83,7 +83,7 @@ class ZyteAPIResponse(ZyteAPIMixin, Response):
         return cls(
             url=api_response["url"],
             status=200,
-            body=b64decode(api_response["httpResponseBody"]),
+            body=b64decode(api_response.get("httpResponseBody") or ""),
             request=request,
             flags=["zyte-api"],
             headers=cls._prepare_headers(api_response.get("httpResponseHeaders")),
@@ -109,12 +109,6 @@ def process_response(
         # Using TextResponse because browserHtml always returns a browser-rendered page
         # even when requesting files (like images)
         return ZyteAPITextResponse.from_api_response(api_response, request=request)
-
-    if api_response.get("httpResponseBody") is None:
-        raise ValueError(
-            "Can't instantiate ZyteAPITextResponse/ZyteAPIResopnse without "
-            "'browserHtml' or 'httpResponseBody'."
-        )
 
     if api_response.get("httpResponseHeaders") and api_response.get("httpResponseBody"):
         response_cls = responsetypes.from_args(

--- a/scrapy_zyte_api/responses.py
+++ b/scrapy_zyte_api/responses.py
@@ -1,5 +1,5 @@
 from base64 import b64decode
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union, Tuple
 
 from scrapy import Request
 from scrapy.http import Response, TextResponse
@@ -20,12 +20,6 @@ class ZyteAPIMixin:
     def __init__(self, *args, zyte_api: Dict = None, **kwargs):
         super().__init__(*args, **kwargs)
         self._zyte_api = zyte_api
-
-    def replace(self, *args, **kwargs):
-        """Create a new response with the same attributes except for those given
-        new values.
-        """
-        return super().replace(*args, **kwargs)
 
     @property
     def zyte_api(self) -> Optional[Dict]:
@@ -48,6 +42,9 @@ class ZyteAPIMixin:
 
 
 class ZyteAPITextResponse(ZyteAPIMixin, TextResponse):
+
+    attributes: Tuple[str, ...] = TextResponse.attributes + ("zyte_api",)
+
     @classmethod
     def from_api_response(cls, api_response: Dict, *, request: Request = None):
         """Alternative constructor to instantiate the response from the raw
@@ -75,6 +72,9 @@ class ZyteAPITextResponse(ZyteAPIMixin, TextResponse):
 
 
 class ZyteAPIResponse(ZyteAPIMixin, Response):
+
+    attributes: Tuple[str, ...] = Response.attributes + ("zyte_api",)
+
     @classmethod
     def from_api_response(cls, api_response: Dict, *, request: Request = None):
         """Alternative constructor to instantiate the response from the raw

--- a/scrapy_zyte_api/responses.py
+++ b/scrapy_zyte_api/responses.py
@@ -1,5 +1,5 @@
 from base64 import b64decode
-from typing import Dict, List, Optional, Union, Tuple
+from typing import Dict, List, Optional, Tuple, Union
 
 from scrapy import Request
 from scrapy.http import Response, TextResponse
@@ -17,23 +17,23 @@ class ZyteAPIMixin:
         "content-encoding"
     }
 
-    def __init__(self, *args, zyte_api: Dict = None, **kwargs):
+    def __init__(self, *args, raw_api_response: Dict = None, **kwargs):
         super().__init__(*args, **kwargs)
-        self._zyte_api = zyte_api
+        self._raw_api_response = raw_api_response
 
     def replace(self, *args, **kwargs):
-        if kwargs.get("zyte_api"):
-            raise ValueError("Replacing the value of 'zyte_api' isn't allowed.")
+        if kwargs.get("raw_api_response"):
+            raise ValueError("Replacing the value of 'raw_api_response' isn't allowed.")
         return super().replace(*args, **kwargs)
 
     @property
-    def zyte_api(self) -> Optional[Dict]:
+    def raw_api_response(self) -> Optional[Dict]:
         """Contains the raw API response from Zyte API.
 
         To see the full list of parameters and their description, kindly refer to the
         `Zyte API Specification <https://docs.zyte.com/zyte-api/openapi.html#zyte-openapi-spec>`_.
         """
-        return self._zyte_api
+        return self._raw_api_response
 
     @classmethod
     def _prepare_headers(cls, init_headers: Optional[List[Dict[str, str]]]):
@@ -48,7 +48,7 @@ class ZyteAPIMixin:
 
 class ZyteAPITextResponse(ZyteAPIMixin, TextResponse):
 
-    attributes: Tuple[str, ...] = TextResponse.attributes + ("zyte_api",)
+    attributes: Tuple[str, ...] = TextResponse.attributes + ("raw_api_response",)
 
     @classmethod
     def from_api_response(cls, api_response: Dict, *, request: Request = None):
@@ -72,13 +72,13 @@ class ZyteAPITextResponse(ZyteAPIMixin, TextResponse):
             request=request,
             flags=["zyte-api"],
             headers=cls._prepare_headers(api_response.get("httpResponseHeaders")),
-            zyte_api=api_response,
+            raw_api_response=api_response,
         )
 
 
 class ZyteAPIResponse(ZyteAPIMixin, Response):
 
-    attributes: Tuple[str, ...] = Response.attributes + ("zyte_api",)
+    attributes: Tuple[str, ...] = Response.attributes + ("raw_api_response",)
 
     @classmethod
     def from_api_response(cls, api_response: Dict, *, request: Request = None):
@@ -92,7 +92,7 @@ class ZyteAPIResponse(ZyteAPIMixin, Response):
             request=request,
             flags=["zyte-api"],
             headers=cls._prepare_headers(api_response.get("httpResponseHeaders")),
-            zyte_api=api_response,
+            raw_api_response=api_response,
         )
 
 

--- a/scrapy_zyte_api/responses.py
+++ b/scrapy_zyte_api/responses.py
@@ -16,9 +16,9 @@ class ZyteAPIMixin:
         "content-encoding"
     }
 
-    def __init__(self, *args, zyte_api_response: Dict = None, **kwargs):
+    def __init__(self, *args, zyte_api: Dict = None, **kwargs):
         super().__init__(*args, **kwargs)
-        self._zyte_api_response = zyte_api_response
+        self._zyte_api = zyte_api
 
     def replace(self, *args, **kwargs):
         """Create a new response with the same attributes except for those given
@@ -27,13 +27,13 @@ class ZyteAPIMixin:
         return super().replace(*args, **kwargs)
 
     @property
-    def zyte_api_response(self) -> Optional[Dict]:
+    def zyte_api(self) -> Optional[Dict]:
         """Contains the raw API response from Zyte API.
 
         To see the full list of parameters and their description, kindly refer to the
         `Zyte API Specification <https://docs.zyte.com/zyte-api/openapi.html#zyte-openapi-spec>`_.
         """
-        return self._zyte_api_response
+        return self._zyte_api
 
     @classmethod
     def _prepare_headers(cls, init_headers: Optional[List[Dict[str, str]]]):
@@ -60,7 +60,7 @@ class ZyteAPITextResponse(ZyteAPIMixin, TextResponse):
             request=request,
             flags=["zyte-api"],
             headers=cls._prepare_headers(api_response.get("httpResponseHeaders")),
-            zyte_api_response=api_response,
+            zyte_api=api_response,
         )
 
 
@@ -77,5 +77,5 @@ class ZyteAPIResponse(ZyteAPIMixin, Response):
             request=request,
             flags=["zyte-api"],
             headers=cls._prepare_headers(api_response.get("httpResponseHeaders")),
-            zyte_api_response=api_response,
+            zyte_api=api_response,
         )

--- a/scrapy_zyte_api/responses.py
+++ b/scrapy_zyte_api/responses.py
@@ -15,12 +15,8 @@ class ZyteAPIMixin:
     def replace(self, *args, **kwargs):
         """Create a new response with the same attributes except for those given
         new values.
-
-        NOTE: This doesn't support replacing the ``zyte_api_response`` attribute.
         """
-        instance = super().replace(*args, **kwargs)
-        instance._zyte_api_response = self.zyte_api_response
-        return instance
+        return super().replace(*args, **kwargs)
 
     @property
     def zyte_api_response(self) -> Optional[Dict]:

--- a/scrapy_zyte_api/responses.py
+++ b/scrapy_zyte_api/responses.py
@@ -6,9 +6,19 @@ from scrapy.http import Response, TextResponse
 
 
 class ZyteAPIMixin:
-    def __init__(self, *args, zyte_api_response=None, **kwargs):
+    def __init__(self, *args, zyte_api_response: Dict = None, **kwargs):
         super().__init__(*args, **kwargs)
         self._zyte_api_response = zyte_api_response
+
+    def replace(self, *args, **kwargs):
+        """Create a new response with the same attributes except for those given
+        new values.
+
+        NOTE: This doesn't support replacing the ``zyte_api_response`` attribute.
+        """
+        instance = super().replace(*args, **kwargs)
+        instance._zyte_api_response = self.zyte_api_response
+        return instance
 
     @property
     def zyte_api_response(self) -> Dict:

--- a/scrapy_zyte_api/responses.py
+++ b/scrapy_zyte_api/responses.py
@@ -4,6 +4,8 @@ from typing import Dict, List, Optional
 from scrapy import Request
 from scrapy.http import Response, TextResponse
 
+_ENCODING = "utf-8"
+
 
 class ZyteAPIMixin:
     def __init__(self, *args, zyte_api_response: Dict = None, **kwargs):
@@ -45,7 +47,8 @@ class ZyteAPITextResponse(ZyteAPIMixin, TextResponse):
         return cls(
             url=api_response["url"],
             status=200,
-            body=api_response["browserHtml"].encode("utf-8"),
+            body=api_response["browserHtml"].encode(_ENCODING),
+            encoding=_ENCODING,
             request=request,
             flags=["zyte-api"],
             headers=cls._prepare_headers(api_response.get("httpResponseHeaders")),

--- a/scrapy_zyte_api/responses.py
+++ b/scrapy_zyte_api/responses.py
@@ -21,7 +21,7 @@ class ZyteAPIMixin:
         return instance
 
     @property
-    def zyte_api_response(self) -> Dict:
+    def zyte_api_response(self) -> Optional[Dict]:
         """Contains the raw API response from Zyte API.
 
         To see the full list of parameters and their description, kindly refer to the

--- a/scrapy_zyte_api/responses.py
+++ b/scrapy_zyte_api/responses.py
@@ -91,7 +91,7 @@ class ZyteAPIResponse(ZyteAPIMixin, Response):
         )
 
 
-def process_response(
+def _process_response(
     api_response: Dict[str, Union[List[Dict], str]], request: Request
 ) -> Optional[Union[ZyteAPITextResponse, ZyteAPIResponse]]:
     """Given a Zyte API Response and the ``scrapy.Request`` that asked for it,

--- a/scrapy_zyte_api/responses.py
+++ b/scrapy_zyte_api/responses.py
@@ -21,6 +21,11 @@ class ZyteAPIMixin:
         super().__init__(*args, **kwargs)
         self._zyte_api = zyte_api
 
+    def replace(self, *args, **kwargs):
+        if kwargs.get("zyte_api"):
+            raise ValueError("Replacing the value of 'zyte_api' isn't allowed.")
+        return super().replace(*args, **kwargs)
+
     @property
     def zyte_api(self) -> Optional[Dict]:
         """Contains the raw API response from Zyte API.

--- a/scrapy_zyte_api/responses.py
+++ b/scrapy_zyte_api/responses.py
@@ -11,7 +11,12 @@ class ZyteAPIMixin:
         self._zyte_api_response = zyte_api_response
 
     @property
-    def zyte_api_response(self):
+    def zyte_api_response(self) -> Dict:
+        """Contains the raw API response from Zyte API.
+
+        To see the full list of parameters and their description, kindly refer to the
+        `Zyte API Specification <https://docs.zyte.com/zyte-api/openapi.html#zyte-openapi-spec>`_.
+        """
         return self._zyte_api_response
 
     @staticmethod
@@ -24,6 +29,9 @@ class ZyteAPIMixin:
 class ZyteAPITextResponse(ZyteAPIMixin, TextResponse):
     @classmethod
     def from_api_response(cls, api_response: Dict, *, request: Request = None):
+        """Alternative constructor to instantiate the response from the raw
+        Zyte API response.
+        """
         return cls(
             url=api_response["url"],
             status=200,
@@ -38,6 +46,9 @@ class ZyteAPITextResponse(ZyteAPIMixin, TextResponse):
 class ZyteAPIResponse(ZyteAPIMixin, Response):
     @classmethod
     def from_api_response(cls, api_response: Dict, *, request: Request = None):
+        """Alternative constructor to instantiate the response from the raw
+        Zyte API response.
+        """
         return cls(
             url=api_response["url"],
             status=200,

--- a/scrapy_zyte_api/responses.py
+++ b/scrapy_zyte_api/responses.py
@@ -23,14 +23,11 @@ class ZyteAPIMixin:
 
 class ZyteAPITextResponse(ZyteAPIMixin, TextResponse):
     @classmethod
-    def from_api_response(
-        cls, api_response: Dict, *, request: Request = None, encoding: str = "utf-8"
-    ):
+    def from_api_response(cls, api_response: Dict, *, request: Request = None):
         return cls(
             url=api_response["url"],
             status=200,
-            body=api_response["browserHtml"].encode(encoding),
-            encoding=encoding,
+            body=api_response["browserHtml"].encode("utf-8"),
             request=request,
             flags=["zyte-api"],
             headers=cls._prepare_headers(api_response.get("httpResponseHeaders")),

--- a/scrapy_zyte_api/responses.py
+++ b/scrapy_zyte_api/responses.py
@@ -1,0 +1,52 @@
+from base64 import b64decode
+from typing import Dict, List, Optional
+
+from scrapy import Request
+from scrapy.http import Response, TextResponse
+
+
+class ZyteAPIMixin:
+    def __init__(self, *args, zyte_api_response=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._zyte_api_response = zyte_api_response
+
+    @property
+    def zyte_api_response(self):
+        return self._zyte_api_response
+
+    @staticmethod
+    def _prepare_headers(init_headers: Optional[List[Dict[str, str]]]):
+        if not init_headers:
+            return None
+        return {h["name"]: h["value"] for h in init_headers}
+
+
+class ZyteAPITextResponse(ZyteAPIMixin, TextResponse):
+    @classmethod
+    def from_api_response(
+        cls, api_response: Dict, *, request: Request = None, encoding: str = "utf-8"
+    ):
+        return cls(
+            url=api_response["url"],
+            status=200,
+            body=api_response["browserHtml"].encode(encoding),
+            encoding=encoding,
+            request=request,
+            flags=["zyte-api"],
+            headers=cls._prepare_headers(api_response.get("httpResponseHeaders")),
+            zyte_api_response=api_response,
+        )
+
+
+class ZyteAPIResponse(ZyteAPIMixin, Response):
+    @classmethod
+    def from_api_response(cls, api_response: Dict, *, request: Request = None):
+        return cls(
+            url=api_response["url"],
+            status=200,
+            body=b64decode(api_response["httpResponseBody"]),
+            request=request,
+            flags=["zyte-api"],
+            headers=cls._prepare_headers(api_response.get("httpResponseHeaders")),
+            zyte_api_response=api_response,
+        )

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -45,7 +45,7 @@ class _RequestHandler(BaseHTTPRequestHandler):
                     {"name": "test_header", "value": "test_value"}
                 ]
             if post_data.get("jobId") is None:
-                browser_html = "<html></html>"
+                browser_html = "<html><body>Hello<h1>World!</h1></body></html>"
             else:
                 browser_html = f"<html>{post_data['jobId']}</html>"
             if post_data.get("browserHtml"):

--- a/tests/test_api_requests.py
+++ b/tests/test_api_requests.py
@@ -44,7 +44,7 @@ class TestAPI:
                 coro = handler._download_request(req, Spider("test"))
                 assert iscoroutine(coro)
                 assert not isinstance(coro, Deferred)
-                resp = await coro  # NOQA
+                resp = await coro  # type: ignore
 
             assert isinstance(resp, TextResponse)
             assert resp.request is req
@@ -81,7 +81,7 @@ class TestAPI:
                 coro = handler._download_request(req, Spider("test"))
                 assert iscoroutine(coro)
                 assert not isinstance(coro, Deferred)
-                resp = await coro  # NOQA
+                resp = await coro  # type: ignore
 
             assert isinstance(resp, Response)
             assert resp.request is req
@@ -109,7 +109,7 @@ class TestAPI:
                 coro = handler._download_request(req, Spider("test"))
                 assert iscoroutine(coro)
                 assert not isinstance(coro, Deferred)
-                resp = await coro  # NOQA
+                resp = await coro  # type: ignore
 
             assert resp.request is req
             assert resp.url == req.url

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -180,13 +180,15 @@ def test_response_headers_removal(api_response, cls):
 
 
 def test_process_response_no_body():
-    """The process_response() function cannot produce the appropriate Zyte API
-    Response for Scrapy if it doesn't have a 'browserHtml' or 'httpResponseBody'.
+    """The process_response() function should handle missing 'browserHtml' or
+    'httpResponseBody'.
     """
     api_response = {"url": "https://example.com", "product": {"name": "shoes"}}
 
-    with pytest.raises(ValueError):
-        process_response(api_response, Request(api_response["url"]))
+    resp = process_response(api_response, Request(api_response["url"]))
+
+    assert isinstance(resp, Response)
+    assert resp.body == b""
 
 
 def test_process_response_body_only():

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -1,8 +1,15 @@
 from base64 import b64encode
 
 import pytest
+from scrapy import Request
+from scrapy.exceptions import NotSupported
+from scrapy.http import Response, TextResponse
 
-from scrapy_zyte_api.responses import ZyteAPIResponse, ZyteAPITextResponse
+from scrapy_zyte_api.responses import (
+    ZyteAPIResponse,
+    ZyteAPITextResponse,
+    process_response,
+)
 
 PAGE_CONTENT = "<html><body>The cake is a lie!</body></html>"
 URL = "https://example.com"
@@ -137,6 +144,13 @@ def test_non_utf8_response():
     assert response.encoding == "utf-8"
 
 
+BODY = "<html><body>Hello<h1>World!✨</h1></body></html>"
+
+
+def format_to_httpResponseBody(body, encoding="utf-8"):
+    return b64encode(body.encode(encoding)).decode("utf-8")
+
+
 @pytest.mark.parametrize(
     "api_response,cls",
     [
@@ -163,3 +177,211 @@ def test_response_headers_removal(api_response, cls):
     assert (
         response.zyte_api["httpResponseHeaders"] == raw_response["httpResponseHeaders"]
     )
+
+
+def test_process_response_no_body():
+    """The process_response() function cannot produce the appropriate Zyte API
+    Response for Scrapy if it doesn't have a 'browserHtml' or 'httpResponseBody'.
+    """
+    api_response = {"url": "https://example.com", "product": {"name": "shoes"}}
+
+    with pytest.raises(ValueError):
+        process_response(api_response, Request(api_response["url"]))
+
+
+def test_process_response_body_only():
+    """Having the Body but with no Headers won't allow us to decode the contents
+    with the proper encoding.
+
+    Thus, we won't have access to css/xpath selectors.
+    """
+    encoding = "utf-8"
+    api_response = {
+        "url": "https://example.com",
+        "httpResponseBody": format_to_httpResponseBody(BODY, encoding=encoding),
+    }
+
+    resp = process_response(api_response, Request(api_response["url"]))
+
+    assert isinstance(resp, Response)
+    with pytest.raises(NotSupported):
+        assert resp.css("h1 ::text")
+    with pytest.raises(NotSupported):
+        assert resp.xpath("//body/text()")
+
+
+@pytest.mark.xfail(reason="encoding inference is not supported for now")
+def test_process_response_body_only_infer_encoding():
+    """The ``scrapy.TextResponse`` class has the ability to check the encoding
+    by inferring it in the HTML body.
+
+    However, this is a bit tricky since we need to somehow ensure that the body
+    we're receiving is "text/html". We can't fully determine that without the
+    headers.
+    """
+    encoding = "gb18030"
+    body = (
+        "<html>"
+        '<head><meta http-equiv="Content-Type" content="text/html; charset="gb2312"></head>'
+        "<body>Some ✨ contents</body>"
+        "</html>"
+    )
+
+    api_response = {
+        "url": "https://example.com",
+        "httpResponseBody": format_to_httpResponseBody(body, encoding=encoding),
+    }
+
+    resp = process_response(api_response, Request(api_response["url"]))
+
+    assert isinstance(resp, TextResponse)
+    assert resp.css("body ::text").get() == "Some ✨ contents"
+    assert resp.xpath("//body/text()").getall() == ["Some ✨ contents"]
+
+
+@pytest.mark.parametrize(
+    "encoding,content_type",
+    [
+        ("utf-8", "text/html; charset=UTF-8"),
+        ("gb18030", "text/html; charset=gb2312"),
+    ],
+)
+def test_process_response_body_and_headers(encoding, content_type):
+    """Having access to the Headers allow us to properly decode the contents
+    and will have access to the css/xpath selectors.
+    """
+    api_response = {
+        "url": "https://example.com",
+        "httpResponseBody": format_to_httpResponseBody(BODY, encoding=encoding),
+        "httpResponseHeaders": [{"name": "Content-Type", "value": content_type}],
+    }
+
+    resp = process_response(api_response, Request(api_response["url"]))
+
+    assert isinstance(resp, TextResponse)
+    assert resp.css("h1 ::text").get() == "World!✨"
+    assert resp.xpath("//body/text()").getall() == ["Hello"]
+    assert resp.encoding == encoding
+
+
+@pytest.mark.parametrize(
+    "body,expected,actual_encoding,inferred_encoding",
+    [
+        ("<html><body>plain</body></html>", "plain", "cp1252", "cp1252"),
+        (
+            "<html><body>✨</body></html>",
+            "✨",
+            "utf-8",
+            "utf-8",
+        ),
+        (
+            "<html><body>✨</body></html>",
+            "✨",
+            "utf-16",
+            "utf-16-le",
+        ),
+        (
+            """<html><head><meta http-equiv="Content-Type" content="text/html; charset="gb2312">
+            </head><body>✨</body></html>""",
+            "✨",
+            "gb18030",
+            None,
+        ),
+    ],
+)
+def test_process_response_body_and_headers_but_no_encoding(
+    body, expected, actual_encoding, inferred_encoding
+):
+    """Should both the body and headers are present but no 'Content-Type' encoding
+    can be derived, it should infer from the body contents.
+    """
+    api_response = {
+        "url": "https://example.com",
+        "httpResponseBody": format_to_httpResponseBody(body, encoding=actual_encoding),
+        "httpResponseHeaders": [{"name": "X-Value", "value": "some_value"}],
+    }
+
+    resp = process_response(api_response, Request(api_response["url"]))
+
+    assert isinstance(resp, TextResponse)
+
+    if inferred_encoding:
+        assert resp.css("body ::text").get() == expected
+        assert resp.xpath("//body/text()").get() == expected
+        assert resp.encoding == inferred_encoding
+
+    # Scrapy's ``TextResponse`` built-in inference only works on "utf-8" and
+    # "Latin-1" based encodings.
+    else:
+        assert resp.css("body ::text").get() != expected
+        assert resp.xpath("//body/text()").get() != expected
+        assert resp.encoding == "ascii"
+
+
+def test_process_response_body_and_headers_mismatch():
+    """If the actual contents have a mismatch in terms of its encoding, we won't
+    properly decode the ✨ emoji.
+    """
+    encoding = "utf-8"
+    api_response = {
+        "url": "https://example.com",
+        "httpResponseBody": format_to_httpResponseBody(BODY, encoding=encoding),
+        "httpResponseHeaders": [
+            {"name": "Content-Type", "value": "text/html; charset=gb2312"}
+        ],
+    }
+
+    resp = process_response(api_response, Request(api_response["url"]))
+
+    assert isinstance(resp, TextResponse)
+    assert resp.css("h1 ::text").get() != "World!✨"  # mismatch
+    assert resp.xpath("//body/text()").getall() == ["Hello"]
+    assert resp.encoding == "gb18030"
+
+
+def test_process_response_non_text():
+    """Non-textual responses like images, files, etc. won't have access to the
+    css/xpath selectors.
+    """
+    api_response = {
+        "url": "https://example.com/sprite.gif",
+        "httpResponseBody": b"",
+        "httpResponseHeaders": [
+            {
+                "name": "Content-Type",
+                "value": "image/gif",
+            }
+        ],
+    }
+    resp = process_response(api_response, Request(api_response["url"]))
+
+    assert isinstance(resp, Response)
+    with pytest.raises(NotSupported):
+        assert resp.css("h1 ::text")
+    with pytest.raises(NotSupported):
+        assert resp.xpath("//body/text()")
+
+
+@pytest.mark.parametrize(
+    "api_response",
+    [
+        {"url": "https://example.com", "browserHtml": BODY},
+        {
+            "url": "https://example.com",
+            "browserHtml": BODY,
+            "httpResponseHeaders": [
+                {
+                    "name": "Content-Type",
+                    "value": "text/html; charset=UTF-8",
+                }
+            ],
+        },
+    ],
+)
+def test_process_response_browserhtml(api_response):
+    resp = process_response(api_response, Request(api_response["url"]))
+
+    assert isinstance(resp, TextResponse)
+    assert resp.css("h1 ::text").get() == "World!✨"
+    assert resp.xpath("//body/text()").getall() == ["Hello"]
+    assert resp.encoding == "utf-8"  # Zyte API is consistent with this on browserHtml

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -8,7 +8,7 @@ from scrapy.http import Response, TextResponse
 from scrapy_zyte_api.responses import (
     ZyteAPIResponse,
     ZyteAPITextResponse,
-    process_response,
+    _process_response,
 )
 
 PAGE_CONTENT = "<html><body>The cake is a lie!</body></html>"
@@ -170,19 +170,19 @@ def test_response_headers_removal(api_response, cls):
     )
 
 
-def test_process_response_no_body():
-    """The process_response() function should handle missing 'browserHtml' or
+def test__process_response_no_body():
+    """The _process_response() function should handle missing 'browserHtml' or
     'httpResponseBody'.
     """
     api_response = {"url": "https://example.com", "product": {"name": "shoes"}}
 
-    resp = process_response(api_response, Request(api_response["url"]))
+    resp = _process_response(api_response, Request(api_response["url"]))
 
     assert isinstance(resp, Response)
     assert resp.body == b""
 
 
-def test_process_response_body_only():
+def test__process_response_body_only():
     """Having the Body but with no Headers won't allow us to decode the contents
     with the proper encoding.
 
@@ -194,7 +194,7 @@ def test_process_response_body_only():
         "httpResponseBody": format_to_httpResponseBody(BODY, encoding=encoding),
     }
 
-    resp = process_response(api_response, Request(api_response["url"]))
+    resp = _process_response(api_response, Request(api_response["url"]))
 
     assert isinstance(resp, Response)
     with pytest.raises(NotSupported):
@@ -204,7 +204,7 @@ def test_process_response_body_only():
 
 
 @pytest.mark.xfail(reason="encoding inference is not supported for now")
-def test_process_response_body_only_infer_encoding():
+def test__process_response_body_only_infer_encoding():
     """The ``scrapy.TextResponse`` class has the ability to check the encoding
     by inferring it in the HTML body.
 
@@ -225,7 +225,7 @@ def test_process_response_body_only_infer_encoding():
         "httpResponseBody": format_to_httpResponseBody(body, encoding=encoding),
     }
 
-    resp = process_response(api_response, Request(api_response["url"]))
+    resp = _process_response(api_response, Request(api_response["url"]))
 
     assert isinstance(resp, TextResponse)
     assert resp.css("body ::text").get() == "Some ✨ contents"
@@ -239,7 +239,7 @@ def test_process_response_body_only_infer_encoding():
         ("gb18030", "text/html; charset=gb2312"),
     ],
 )
-def test_process_response_body_and_headers(encoding, content_type):
+def test__process_response_body_and_headers(encoding, content_type):
     """Having access to the Headers allow us to properly decode the contents
     and will have access to the css/xpath selectors.
     """
@@ -249,7 +249,7 @@ def test_process_response_body_and_headers(encoding, content_type):
         "httpResponseHeaders": [{"name": "Content-Type", "value": content_type}],
     }
 
-    resp = process_response(api_response, Request(api_response["url"]))
+    resp = _process_response(api_response, Request(api_response["url"]))
 
     assert isinstance(resp, TextResponse)
     assert resp.css("h1 ::text").get() == "World!✨"
@@ -282,7 +282,7 @@ def test_process_response_body_and_headers(encoding, content_type):
         ),
     ],
 )
-def test_process_response_body_and_headers_but_no_encoding(
+def test__process_response_body_and_headers_but_no_encoding(
     body, expected, actual_encoding, inferred_encoding
 ):
     """Should both the body and headers are present but no 'Content-Type' encoding
@@ -294,7 +294,7 @@ def test_process_response_body_and_headers_but_no_encoding(
         "httpResponseHeaders": [{"name": "X-Value", "value": "some_value"}],
     }
 
-    resp = process_response(api_response, Request(api_response["url"]))
+    resp = _process_response(api_response, Request(api_response["url"]))
 
     assert isinstance(resp, TextResponse)
 
@@ -311,7 +311,7 @@ def test_process_response_body_and_headers_but_no_encoding(
         assert resp.encoding == "ascii"
 
 
-def test_process_response_body_and_headers_mismatch():
+def test__process_response_body_and_headers_mismatch():
     """If the actual contents have a mismatch in terms of its encoding, we won't
     properly decode the ✨ emoji.
     """
@@ -324,7 +324,7 @@ def test_process_response_body_and_headers_mismatch():
         ],
     }
 
-    resp = process_response(api_response, Request(api_response["url"]))
+    resp = _process_response(api_response, Request(api_response["url"]))
 
     assert isinstance(resp, TextResponse)
     assert resp.css("h1 ::text").get() != "World!✨"  # mismatch
@@ -332,7 +332,7 @@ def test_process_response_body_and_headers_mismatch():
     assert resp.encoding == "gb18030"
 
 
-def test_process_response_non_text():
+def test__process_response_non_text():
     """Non-textual responses like images, files, etc. won't have access to the
     css/xpath selectors.
     """
@@ -346,7 +346,7 @@ def test_process_response_non_text():
             }
         ],
     }
-    resp = process_response(api_response, Request(api_response["url"]))
+    resp = _process_response(api_response, Request(api_response["url"]))
 
     assert isinstance(resp, Response)
     with pytest.raises(NotSupported):
@@ -371,8 +371,8 @@ def test_process_response_non_text():
         },
     ],
 )
-def test_process_response_browserhtml(api_response):
-    resp = process_response(api_response, Request(api_response["url"]))
+def test__process_response_browserhtml(api_response):
+    resp = _process_response(api_response, Request(api_response["url"]))
 
     assert isinstance(resp, TextResponse)
     assert resp.css("h1 ::text").get() == "World!✨"

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -105,22 +105,9 @@ def test_response_replace(api_response, cls):
     new_response = orig_response.replace(url="https://new-example.com")
     assert new_response.url == "https://new-example.com"
 
-
-@pytest.mark.xfail
-@pytest.mark.parametrize(
-    "api_response,cls",
-    [
-        (api_response_browser, ZyteAPITextResponse),
-        (api_response_body, ZyteAPIResponse),
-    ],
-)
-def test_response_replace_zyte_api(api_response, cls):
-    orig_response = cls.from_api_response(api_response())
-
-    # The ``zyte_api`` should not be replaced.
     new_zyte_api = {"overridden": "value"}
     new_response = orig_response.replace(zyte_api=new_zyte_api)
-    assert new_response.zyte_api == api_response()
+    assert new_response.zyte_api == new_zyte_api
 
 
 def test_non_utf8_response():

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -79,3 +79,23 @@ def test_text_from_api_response(api_response, cls):
     assert response.certificate is None
     assert response.ip_address is None
     assert response.protocol is None
+
+
+@pytest.mark.parametrize(
+    "api_response,cls",
+    [
+        (api_response_browser, ZyteAPITextResponse),
+        (api_response_body, ZyteAPIResponse),
+    ],
+)
+def test_response_replace(api_response, cls):
+    orig_response = cls.from_api_response(api_response())
+
+    # The ``zyte_api_response`` should not be replaced.
+    new_response = orig_response.replace(zyte_api_response={"overridden": "value"})
+    assert new_response.zyte_api_response == orig_response.zyte_api_response
+
+    # It should still work the same way
+    new_response = orig_response.replace(status=404)
+    assert new_response.status == 404
+    assert new_response.zyte_api_response == orig_response.zyte_api_response

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -109,9 +109,22 @@ def test_response_replace(api_response, cls):
     assert new_response.zyte_api == api_response()
 
     # The Zyte API response must also be fully replaceable
-    new_zyte_api = {"overridden": "value"}
+    new_zyte_api = {
+        "url": "https://another-website.com",
+        "httpResponseHeaders": {"name": "Content-Type", "value": "application/json"}
+    }
+    if cls == ZyteAPITextResponse:
+        new_zyte_api["browserHtml"] = "Hello World!"
+    elif cls == ZyteAPIResponse:
+        new_zyte_api["httpResponseBody"] = "Hello World!"
+
     new_response = orig_response.replace(zyte_api=new_zyte_api)
     assert new_response.zyte_api == new_zyte_api
+
+    # But it doesn't change the contextually similar attributes of the response
+    new_response.url == orig_response.url
+    new_response.body == orig_response.body
+    new_response.headers == orig_response.headers
 
 
 def test_non_utf8_response():

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -108,23 +108,14 @@ def test_response_replace(api_response, cls):
     # Ensure that the Zyte API response is intact
     assert new_response.zyte_api == api_response()
 
-    # The Zyte API response must also be fully replaceable
     new_zyte_api = {
         "url": "https://another-website.com",
         "httpResponseHeaders": {"name": "Content-Type", "value": "application/json"}
     }
-    if cls == ZyteAPITextResponse:
-        new_zyte_api["browserHtml"] = "Hello World!"
-    elif cls == ZyteAPIResponse:
-        new_zyte_api["httpResponseBody"] = "Hello World!"
 
-    new_response = orig_response.replace(zyte_api=new_zyte_api)
-    assert new_response.zyte_api == new_zyte_api
-
-    # But it doesn't change the contextually similar attributes of the response
-    new_response.url == orig_response.url
-    new_response.body == orig_response.body
-    new_response.headers == orig_response.headers
+    # Attempting to replace the zyte_api value would raise an error
+    with pytest.raises(ValueError):
+        orig_response.replace(zyte_api=new_zyte_api)
 
 
 def test_non_utf8_response():

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -91,14 +91,29 @@ def test_text_from_api_response(api_response, cls):
 def test_response_replace(api_response, cls):
     orig_response = cls.from_api_response(api_response())
 
-    # The ``zyte_api_response`` should not be replaced.
-    new_response = orig_response.replace(zyte_api_response={"overridden": "value"})
-    assert new_response.zyte_api_response == orig_response.zyte_api_response
-
     # It should still work the same way
     new_response = orig_response.replace(status=404)
     assert new_response.status == 404
-    assert new_response.zyte_api_response == orig_response.zyte_api_response
+
+    new_response = orig_response.replace(url="https://new-example.com")
+    assert new_response.url == "https://new-example.com"
+
+
+@pytest.mark.xfail
+@pytest.mark.parametrize(
+    "api_response,cls",
+    [
+        (api_response_browser, ZyteAPITextResponse),
+        (api_response_body, ZyteAPIResponse),
+    ],
+)
+def test_response_replace_zyte_api_response(api_response, cls):
+    orig_response = cls.from_api_response(api_response())
+
+    # The ``zyte_api_response`` should not be replaced.
+    new_zyte_api_response = {"overridden": "value"}
+    new_response = orig_response.replace(zyte_api_response=new_zyte_api_response)
+    assert new_response.zyte_api_response == api_response()
 
 
 def test_non_utf8_response():

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -105,6 +105,10 @@ def test_response_replace(api_response, cls):
     new_response = orig_response.replace(url="https://new-example.com")
     assert new_response.url == "https://new-example.com"
 
+    # Ensure that the Zyte API response is intact
+    assert new_response.zyte_api == api_response()
+
+    # The Zyte API response must also be fully replaceable
     new_zyte_api = {"overridden": "value"}
     new_response = orig_response.replace(zyte_api=new_zyte_api)
     assert new_response.zyte_api == new_zyte_api

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -45,8 +45,8 @@ EXPECTED_BODY = PAGE_CONTENT.encode("utf-8")
     ],
 )
 def test_init(api_response, cls):
-    response = cls(URL, zyte_api_response=api_response())
-    assert response.zyte_api_response == api_response()
+    response = cls(URL, zyte_api=api_response())
+    assert response.zyte_api == api_response()
 
     assert response.url == URL
     assert response.status == 200
@@ -68,7 +68,7 @@ def test_init(api_response, cls):
 )
 def test_text_from_api_response(api_response, cls):
     response = cls.from_api_response(api_response())
-    assert response.zyte_api_response == api_response()
+    assert response.zyte_api == api_response()
 
     assert response.url == URL
     assert response.status == 200
@@ -107,18 +107,18 @@ def test_response_replace(api_response, cls):
         (api_response_body, ZyteAPIResponse),
     ],
 )
-def test_response_replace_zyte_api_response(api_response, cls):
+def test_response_replace_zyte_api(api_response, cls):
     orig_response = cls.from_api_response(api_response())
 
-    # The ``zyte_api_response`` should not be replaced.
-    new_zyte_api_response = {"overridden": "value"}
-    new_response = orig_response.replace(zyte_api_response=new_zyte_api_response)
-    assert new_response.zyte_api_response == api_response()
+    # The ``zyte_api`` should not be replaced.
+    new_zyte_api = {"overridden": "value"}
+    new_response = orig_response.replace(zyte_api=new_zyte_api)
+    assert new_response.zyte_api == api_response()
 
 
 def test_non_utf8_response():
     content = "<html><body>Some non-ASCII ✨ chars</body></html>"
-    sample_zyte_api_response = {
+    sample_zyte_api = {
         "url": URL,
         "browserHtml": content,
         "httpResponseHeaders": [
@@ -132,7 +132,7 @@ def test_non_utf8_response():
     # for it. This is the default encoding for the "browserHtml" contents from
     # Zyte API. Thus, even if the Response Headers or <meta> tags indicate a
     # different encoding, it should still be treated as "utf-8".
-    response = ZyteAPITextResponse.from_api_response(sample_zyte_api_response)
+    response = ZyteAPITextResponse.from_api_response(sample_zyte_api)
     assert response.text == content
     assert response.encoding == "utf-8"
 
@@ -148,7 +148,7 @@ def test_response_headers_removal(api_response, cls):
     """Headers like 'Content-Encoding' should be removed later in the response
     instance returned to Scrapy.
 
-    However, it should still be present inside 'zyte_api_response.headers'.
+    However, it should still be present inside 'zyte_api.headers'.
     """
     additional_headers = [
         {"name": "Content-Encoding", "value": "gzip"},
@@ -161,6 +161,5 @@ def test_response_headers_removal(api_response, cls):
 
     assert response.headers == {b"X-Some-Other-Value": [b"123"]}
     assert (
-        response.zyte_api_response["httpResponseHeaders"]
-        == raw_response["httpResponseHeaders"]
+        response.zyte_api["httpResponseHeaders"] == raw_response["httpResponseHeaders"]
     )

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -1,0 +1,81 @@
+from base64 import b64encode
+
+import pytest
+
+from scrapy_zyte_api.responses import ZyteAPIResponse, ZyteAPITextResponse
+
+PAGE_CONTENT = "<html><body>The cake is a lie!</body></html>"
+URL = "https://example.com"
+
+
+def api_response_browser():
+    return {
+        "url": URL,
+        "browserHtml": PAGE_CONTENT,
+        "javascript": True,
+        "echoData": {"some_value": "here"},
+        "httpResponseHeaders": [
+            {"name": "Content-Type", "value": "text/html"},
+            {"name": "Content-Length", "value": len(PAGE_CONTENT)},
+        ],
+    }
+
+
+def api_response_body():
+    return {
+        "url": "https://example.com",
+        "httpResponseBody": b64encode(PAGE_CONTENT.encode("utf-8")),
+        "echoData": {"some_value": "here"},
+        "httpResponseHeaders": [
+            {"name": "Content-Type", "value": "text/html"},
+            {"name": "Content-Length", "value": len(PAGE_CONTENT)},
+        ],
+    }
+
+
+EXPECTED_HEADERS = {b"Content-Type": [b"text/html"], b"Content-Length": [b"44"]}
+EXPECTED_BODY = PAGE_CONTENT.encode("utf-8")
+
+
+@pytest.mark.parametrize(
+    "api_response,cls",
+    [
+        (api_response_browser, ZyteAPITextResponse),
+        (api_response_body, ZyteAPIResponse),
+    ],
+)
+def test_init(api_response, cls):
+    response = cls(URL, zyte_api_response=api_response())
+    assert response.zyte_api_response == api_response()
+
+    assert response.url == URL
+    assert response.status == 200
+    assert not response.headers
+    assert response.body == b""
+    assert not response.flags
+    assert response.request is None
+    assert response.certificate is None
+    assert response.ip_address is None
+    assert response.protocol is None
+
+
+@pytest.mark.parametrize(
+    "api_response,cls",
+    [
+        (api_response_browser, ZyteAPITextResponse),
+        (api_response_body, ZyteAPIResponse),
+    ],
+)
+def test_text_from_api_response(api_response, cls):
+    response = cls.from_api_response(api_response())
+    assert response.zyte_api_response == api_response()
+
+    assert response.url == URL
+    assert response.status == 200
+    assert response.headers == EXPECTED_HEADERS
+    assert response.body == EXPECTED_BODY
+    assert response.flags == ["zyte-api"]
+    assert response.request is None
+    assert response.certificate is None
+    assert response.ip_address is None
+    assert response.protocol is None


### PR DESCRIPTION
Fixes #9 

---

The approach of storing the Zyte API response inside the `response.meta` was avoided since it will break the expectation in Scrapy that `response.meta` comes directly from `response.request.meta`, as what [this code snippet](https://github.com/scrapy/scrapy/blob/master/scrapy/http/response/__init__.py#L65-L73) embodies:

```python
@property
def meta(self):
    try:
        return self.request.meta
    except AttributeError:
        raise AttributeError(
            "Response.meta not available, this response "
            "is not tied to any request"
        )
```

In addition, this is what the [official Scrapy docs](https://docs.scrapy.org/en/latest/topics/request-response.html?highlight=response#scrapy.http.Response.meta) says about `response.meta`:

> Unlike the `Response.request` attribute, the `Response.meta` attribute is propagated along redirects and retries, so you will get the original `Request.meta` sent from your spider.

Thus, this PR introduces these new classes which inherits from Scrapy's `Response` and `TextResponse` respectively:

- `ZyteAPITextResponse`
- `ZyteAPIResponse` 

This enables users to retrieve the raw Zyte Data API response as a `dict` via `response.zyte_api_response`.

### TODO:

- [x] more tests
- [x] update README
- [x] update CHANGELOG