### PR TITLE
Adjust n_conn to CONCURRENT_REQUESTS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage.xml
 docs/_build
 *.egg-info/
 __pycache__/
+/test-results/

--- a/scrapy_zyte_api/handler.py
+++ b/scrapy_zyte_api/handler.py
@@ -40,7 +40,10 @@ class ScrapyZyteAPIDownloadHandler(HTTPDownloadHandler):
                 )
                 raise NotConfigured
         self._client: AsyncClient = client
-        logger.info(f"Using Zyte API Key: {self._client.api_key[:7]}")
+        logger.info(
+            "Using a Zyte Data API key ending in %r",
+            self._client.api_key[:7]
+        )
         verify_installed_reactor(
             "twisted.internet.asyncioreactor.AsyncioSelectorReactor"
         )

--- a/scrapy_zyte_api/handler.py
+++ b/scrapy_zyte_api/handler.py
@@ -41,7 +41,7 @@ class ScrapyZyteAPIDownloadHandler(HTTPDownloadHandler):
                 raise NotConfigured
         self._client: AsyncClient = client
         logger.info(
-            "Using a Zyte Data API key ending in %r",
+            "Using a Zyte Data API key starting with %r",
             self._client.api_key[:7]
         )
         verify_installed_reactor(

--- a/scrapy_zyte_api/handler.py
+++ b/scrapy_zyte_api/handler.py
@@ -29,7 +29,13 @@ class ScrapyZyteAPIDownloadHandler(HTTPDownloadHandler):
         if not client:
             try:
                 client = AsyncClient(
-                    api_key=settings.get('ZYTE_API_KEY'),
+                    # To allow users to have a key defined in Scrapy settings
+                    # and in a environment variable, and be able to cause the
+                    # environment variable to be used instead of the setting by
+                    # overriding the setting on the command-line to be an empty
+                    # string, we do not support setting empty string keys
+                    # through settings.
+                    api_key=settings.get('ZYTE_API_KEY') or None,
                     api_url=settings.get('ZYTE_API_URL') or API_URL,
                     n_conn=settings.getint('CONCURRENT_REQUESTS'),
                 )

--- a/scrapy_zyte_api/handler.py
+++ b/scrapy_zyte_api/handler.py
@@ -47,7 +47,9 @@ class ScrapyZyteAPIDownloadHandler(HTTPDownloadHandler):
         self._stats = crawler.stats
         self._job_id = crawler.settings.get("JOB")
         self._zyte_api_default_params = settings.getdict("ZYTE_API_DEFAULT_PARAMS")
-        self._session = create_session(self._client.n_conn)
+        self._session = create_session(
+            connection_pool_size=self._client.n_conn
+        )
 
     def download_request(self, request: Request, spider: Spider) -> Deferred:
         api_params = self._prepare_api_params(request)

--- a/scrapy_zyte_api/handler.py
+++ b/scrapy_zyte_api/handler.py
@@ -25,10 +25,12 @@ class ScrapyZyteAPIDownloadHandler(HTTPDownloadHandler):
         self, settings: Settings, crawler: Crawler, client: AsyncClient = None
     ):
         super().__init__(settings=settings, crawler=crawler)
-        max_concurrent_requests = settings.getint('CONCURRENT_REQUESTS')
         self._client: AsyncClient = (
             client
-            or AsyncClient(n_conn=max_concurrent_requests)
+            or AsyncClient(
+                api_key=settings.get('ZYTE_API_KEY'),
+                n_conn=settings.getint('CONCURRENT_REQUESTS'),
+            )
         )
         verify_installed_reactor(
             "twisted.internet.asyncioreactor.AsyncioSelectorReactor"
@@ -36,7 +38,7 @@ class ScrapyZyteAPIDownloadHandler(HTTPDownloadHandler):
         self._stats = crawler.stats
         self._job_id = crawler.settings.get("JOB")
         self._zyte_api_default_params = settings.getdict("ZYTE_API_DEFAULT_PARAMS")
-        self._session = create_session(max_concurrent_requests)
+        self._session = create_session(self._client.n_conn)
 
     @classmethod
     def from_crawler(cls, crawler):

--- a/scrapy_zyte_api/handler.py
+++ b/scrapy_zyte_api/handler.py
@@ -25,14 +25,18 @@ class ScrapyZyteAPIDownloadHandler(HTTPDownloadHandler):
         self, settings: Settings, crawler: Crawler, client: AsyncClient = None
     ):
         super().__init__(settings=settings, crawler=crawler)
-        self._client: AsyncClient = client if client else AsyncClient()
+        max_concurrent_requests = settings.getint('CONCURRENT_REQUESTS')
+        self._client: AsyncClient = (
+            client
+            or AsyncClient(n_conn=max_concurrent_requests)
+        )
         verify_installed_reactor(
             "twisted.internet.asyncioreactor.AsyncioSelectorReactor"
         )
         self._stats = crawler.stats
         self._job_id = crawler.settings.get("JOB")
         self._zyte_api_default_params = settings.getdict("ZYTE_API_DEFAULT_PARAMS")
-        self._session = create_session()
+        self._session = create_session(max_concurrent_requests)
 
     @classmethod
     def from_crawler(cls, crawler):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,19 +1,55 @@
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, contextmanager
+from os import environ
 
-from scrapy.settings import Settings
+from scrapy.utils.misc import create_instance
 from scrapy.utils.test import get_crawler
+from twisted.internet.asyncioreactor import AsyncioSelectorReactor
 from zyte_api.aio.client import AsyncClient
+
+from scrapy_zyte_api.handler import ScrapyZyteAPIDownloadHandler
+
+
+_API_KEY = 'a'
+
+DEFAULT_CLIENT_CONCURRENCY = AsyncClient(api_key=_API_KEY).n_conn
+SETTINGS = {
+    'DOWNLOAD_HANDLERS': {
+        'http': 'scrapy_zyte_api.handler.ScrapyZyteAPIDownloadHandler',
+        'https': 'scrapy_zyte_api.handler.ScrapyZyteAPIDownloadHandler'
+    },
+    'ZYTE_API_KEY': _API_KEY,
+    'TWISTED_REACTOR': AsyncioSelectorReactor,
+}
+UNSET = object()
 
 
 @asynccontextmanager
-async def make_handler(settings_dict: dict, api_url: str):
-    from scrapy_zyte_api.handler import ScrapyZyteAPIDownloadHandler
-
-    crawler = get_crawler(settings_dict=settings_dict)
-    handler = ScrapyZyteAPIDownloadHandler(
-        Settings(settings_dict), crawler=crawler, client=AsyncClient(api_url=api_url)
+async def make_handler(settings: dict, api_url: str):
+    settings = settings or {}
+    settings.update(
+        {
+            "ZYTE_API_KEY": "a",
+            "ZYTE_API_URL": api_url,
+        }
+    )
+    crawler = get_crawler(settings_dict=settings)
+    handler = create_instance(
+        ScrapyZyteAPIDownloadHandler,
+        settings=None,
+        crawler=crawler,
     )
     try:
         yield handler
     finally:
         await handler._close()  # NOQA
+
+
+@contextmanager
+def set_env(**env_vars):
+    old_environ = dict(environ)
+    environ.update(env_vars)
+    try:
+        yield
+    finally:
+        environ.clear()
+        environ.update(old_environ)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
 pytest>=6.2.5
-pytest-asyncio>=0.16.0
+pytest-twisted
 pytest-cov>=3.0.0

--- a/tests/test_api_requests.py
+++ b/tests/test_api_requests.py
@@ -279,7 +279,7 @@ async def test_higher_concurrency():
     response_indexes = []
     expected_first_indexes = {0, concurrency - 1}
     fast_seconds = 0.001
-    slow_seconds = 0.02
+    slow_seconds = 0.1
 
     with MockServer(DelayedResource) as server:
 

--- a/tests/test_api_requests.py
+++ b/tests/test_api_requests.py
@@ -10,6 +10,7 @@ from pytest_twisted import ensureDeferred, inlineCallbacks
 from scrapy import Request, Spider
 from scrapy.exceptions import IgnoreRequest, NotConfigured, NotSupported
 from scrapy.http import Response, TextResponse
+from scrapy.utils.defer import deferred_from_coro
 from scrapy.utils.test import get_crawler
 from twisted.internet.asyncioreactor import install as install_asyncio_reactor
 from twisted.internet.defer import Deferred
@@ -251,8 +252,10 @@ async def test_exceptions(
             api_params = handler._prepare_api_params(req)
 
             with pytest.raises(exception_type):  # NOQA
-                await handler._download_request(
-                    api_params, req, Spider("test")
+                await deferred_from_coro(
+                    handler._download_request(
+                        api_params, req, Spider("test")
+                    )  # NOQA
                 )  # NOQA
             assert exception_text in caplog.text
 
@@ -271,9 +274,11 @@ async def test_job_id(job_id):
                 meta={"zyte_api": {"browserHtml": True}},
             )
             api_params = handler._prepare_api_params(req)
-            resp = await handler._download_request(
-                api_params, req, Spider("test")
-            )  # NOQA
+            resp = await deferred_from_coro(
+                handler._download_request(
+                    api_params, req, Spider("test")
+                )  # NOQA
+            )
 
         assert resp.request is req
         assert resp.url == req.url

--- a/tests/test_api_requests.py
+++ b/tests/test_api_requests.py
@@ -6,10 +6,10 @@ from unittest import mock
 
 import pytest
 from _pytest.logging import LogCaptureFixture  # NOQA
+from pytest_twisted import ensureDeferred, inlineCallbacks
 from scrapy import Request, Spider
 from scrapy.exceptions import IgnoreRequest, NotConfigured, NotSupported
 from scrapy.http import Response, TextResponse
-from scrapy.utils.defer import deferred_to_future
 from scrapy.utils.test import get_crawler
 from twisted.internet.asyncioreactor import install as install_asyncio_reactor
 from twisted.internet.defer import Deferred
@@ -25,271 +25,261 @@ except ReactorAlreadyInstalledError:
 os.environ["ZYTE_API_KEY"] = "test"
 
 
-class TestAPI:
-    @staticmethod
-    async def produce_request_response(meta, custom_settings=None):
-        with MockServer() as server:
-            async with make_handler(custom_settings, server.urljoin("/")) as handler:
-                req = Request(
-                    "http://example.com",
-                    method="POST",
-                    meta=meta,
-                )
-                coro_or_deferred = handler.download_request(req, None)
-                if iscoroutine(coro_or_deferred):
-                    resp = await coro_or_deferred  # type: ignore
-                else:
-                    resp = await deferred_to_future(coro_or_deferred)
+@ensureDeferred
+async def produce_request_response(meta, custom_settings=None):
+    with MockServer() as server:
+        async with make_handler(custom_settings, server.urljoin("/")) as handler:
+            req = Request(
+                "http://example.com",
+                method="POST",
+                meta=meta,
+            )
+            resp = await handler.download_request(req, None)
+            return req, resp
 
-                return req, resp
 
-    @pytest.mark.parametrize(
-        "meta",
-        [
-            {"zyte_api": {"browserHtml": True}},
-            {"zyte_api": {"browserHtml": True, "geolocation": "US"}},
-            {"zyte_api": {"browserHtml": True, "geolocation": "US", "echoData": 123}},
-            {"zyte_api": {"browserHtml": True, "randomParameter": None}},
-        ],
-    )
-    @pytest.mark.asyncio
-    async def test_browser_html_request(self, meta: Dict[str, Dict[str, Any]]):
-        req, resp = await self.produce_request_response(meta)
-        assert isinstance(resp, TextResponse)
-        assert resp.request is req
-        assert resp.url == req.url
-        assert resp.status == 200
-        assert "zyte-api" in resp.flags
-        assert resp.body == b"<html><body>Hello<h1>World!</h1></body></html>"
-        assert resp.text == "<html><body>Hello<h1>World!</h1></body></html>"
+@ensureDeferred
+@pytest.mark.parametrize(
+    "meta",
+    [
+        {"zyte_api": {"browserHtml": True}},
+        {"zyte_api": {"browserHtml": True, "geolocation": "US"}},
+        {"zyte_api": {"browserHtml": True, "geolocation": "US", "echoData": 123}},
+        {"zyte_api": {"browserHtml": True, "randomParameter": None}},
+    ],
+)
+async def test_browser_html_request(meta: Dict[str, Dict[str, Any]]):
+    req, resp = await produce_request_response(meta)
+    assert isinstance(resp, TextResponse)
+    assert resp.request is req
+    assert resp.url == req.url
+    assert resp.status == 200
+    assert "zyte-api" in resp.flags
+    assert resp.body == b"<html><body>Hello<h1>World!</h1></body></html>"
+    assert resp.text == "<html><body>Hello<h1>World!</h1></body></html>"
+    assert resp.css("h1 ::text").get() == "World!"
+    assert resp.xpath("//body/text()").getall() == ["Hello"]
+
+
+@pytest.mark.parametrize(
+    "meta",
+    [
+        {"zyte_api": {"httpResponseBody": True}},
+        {"zyte_api": {"httpResponseBody": True, "geolocation": "US"}},
+        {
+            "zyte_api": {
+                "httpResponseBody": True,
+                "geolocation": "US",
+                "echoData": 123,
+            }
+        },
+        {"zyte_api": {"httpResponseBody": True, "randomParameter": None}},
+    ],
+)
+@ensureDeferred
+async def test_http_response_body_request(meta: Dict[str, Dict[str, Any]]):
+    req, resp = await produce_request_response(meta)
+    assert isinstance(resp, Response)
+    assert resp.request is req
+    assert resp.url == req.url
+    assert resp.status == 200
+    assert "zyte-api" in resp.flags
+    assert resp.body == b"<html><body>Hello<h1>World!</h1></body></html>"
+
+    with pytest.raises(NotSupported):
         assert resp.css("h1 ::text").get() == "World!"
+    with pytest.raises(NotSupported):
         assert resp.xpath("//body/text()").getall() == ["Hello"]
 
-    @pytest.mark.parametrize(
-        "meta",
-        [
-            {"zyte_api": {"httpResponseBody": True}},
-            {"zyte_api": {"httpResponseBody": True, "geolocation": "US"}},
-            {
-                "zyte_api": {
-                    "httpResponseBody": True,
-                    "geolocation": "US",
-                    "echoData": 123,
-                }
-            },
-            {"zyte_api": {"httpResponseBody": True, "randomParameter": None}},
-        ],
-    )
-    @pytest.mark.asyncio
-    async def test_http_response_body_request(self, meta: Dict[str, Dict[str, Any]]):
-        req, resp = await self.produce_request_response(meta)
-        assert isinstance(resp, Response)
-        assert resp.request is req
-        assert resp.url == req.url
-        assert resp.status == 200
-        assert "zyte-api" in resp.flags
-        assert resp.body == b"<html><body>Hello<h1>World!</h1></body></html>"
 
-        with pytest.raises(NotSupported):
-            assert resp.css("h1 ::text").get() == "World!"
-        with pytest.raises(NotSupported):
-            assert resp.xpath("//body/text()").getall() == ["Hello"]
+@pytest.mark.parametrize(
+    "meta",
+    [
+        {"zyte_api": {"httpResponseBody": True, "httpResponseHeaders": True}},
+        {"zyte_api": {"browserHtml": True, "httpResponseHeaders": True}},
+    ],
+)
+@ensureDeferred
+async def test_http_response_headers_request(meta: Dict[str, Dict[str, Any]]):
+    req, resp = await produce_request_response(meta)
+    assert resp.request is req
+    assert resp.url == req.url
+    assert resp.status == 200
+    assert "zyte-api" in resp.flags
+    assert resp.body == b"<html><body>Hello<h1>World!</h1></body></html>"
+    assert resp.headers == {b"Test_Header": [b"test_value"]}
 
-    @pytest.mark.parametrize(
-        "meta",
-        [
-            {"zyte_api": {"httpResponseBody": True, "httpResponseHeaders": True}},
-            {"zyte_api": {"browserHtml": True, "httpResponseHeaders": True}},
-        ],
-    )
-    @pytest.mark.asyncio
-    async def test_http_response_headers_request(self, meta: Dict[str, Dict[str, Any]]):
-        req, resp = await self.produce_request_response(meta)
-        assert resp.request is req
-        assert resp.url == req.url
-        assert resp.status == 200
-        assert "zyte-api" in resp.flags
-        assert resp.body == b"<html><body>Hello<h1>World!</h1></body></html>"
-        assert resp.headers == {b"Test_Header": [b"test_value"]}
 
-    @pytest.mark.skipif(
-        sys.version_info < (3, 8), reason="Python3.7 has poor support for AsyncMocks"
-    )
-    @pytest.mark.parametrize(
-        "meta,custom_settings,expected,use_zyte_api",
-        [
-            ({}, {}, {}, False),
-            ({"zyte_api": {}}, {}, {}, False),
-            ({"zyte_api": True}, {}, {}, False),
-            ({"zyte_api": False}, {}, {}, False),
-            (
-                {},
-                {"ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"}},
-                {"browserHtml": True, "geolocation": "CA"},
-                False,
-            ),
-            (
-                {"zyte_api": False},
-                {"ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"}},
-                {},
-                False,
-            ),
-            (
-                {"zyte_api": None},
-                {"ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"}},
-                {},
-                False,
-            ),
-            (
-                {"zyte_api": {}},
-                {"ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"}},
-                {"browserHtml": True, "geolocation": "CA"},
-                True,
-            ),
-            (
-                {"zyte_api": True},
-                {"ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"}},
-                {"browserHtml": True, "geolocation": "CA"},
-                True,
-            ),
-            (
-                {"zyte_api": {"javascript": True, "geolocation": "US"}},
-                {"ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"}},
-                {"browserHtml": True, "geolocation": "US", "javascript": True},
-                True,
-            ),
-        ],
-    )
-    @mock.patch("tests.AsyncClient")
-    @pytest.mark.asyncio
-    async def test_zyte_api_request_meta(
-        self,
-        mock_client,
-        meta: Dict[str, Dict[str, Any]],
-        custom_settings: Dict[str, str],
-        expected: Dict[str, str],
-        use_zyte_api: bool,
-    ):
-        try:
-            # This would always error out since the mocked client doesn't
-            # return the expected API response.
-            await self.produce_request_response(meta, custom_settings=custom_settings)
-        except Exception:
-            pass
+@ensureDeferred
+@pytest.mark.skipif(
+    sys.version_info < (3, 8), reason="Python3.7 has poor support for AsyncMocks"
+)
+@pytest.mark.parametrize(
+    "meta,custom_settings,expected,use_zyte_api",
+    [
+        ({}, {}, {}, False),
+        ({"zyte_api": {}}, {}, {}, False),
+        ({"zyte_api": True}, {}, {}, False),
+        ({"zyte_api": False}, {}, {}, False),
+        (
+            {},
+            {"ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"}},
+            {"browserHtml": True, "geolocation": "CA"},
+            False,
+        ),
+        (
+            {"zyte_api": False},
+            {"ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"}},
+            {},
+            False,
+        ),
+        (
+            {"zyte_api": None},
+            {"ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"}},
+            {},
+            False,
+        ),
+        (
+            {"zyte_api": {}},
+            {"ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"}},
+            {"browserHtml": True, "geolocation": "CA"},
+            True,
+        ),
+        (
+            {"zyte_api": True},
+            {"ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"}},
+            {"browserHtml": True, "geolocation": "CA"},
+            True,
+        ),
+        (
+            {"zyte_api": {"javascript": True, "geolocation": "US"}},
+            {"ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"}},
+            {"browserHtml": True, "geolocation": "US", "javascript": True},
+            True,
+        ),
+    ],
+)
+@mock.patch("tests.AsyncClient")
+async def test_zyte_api_request_meta(
+    mock_client,
+    meta: Dict[str, Dict[str, Any]],
+    custom_settings: Dict[str, str],
+    expected: Dict[str, str],
+    use_zyte_api: bool,
+):
+    try:
+        # This would always error out since the mocked client doesn't
+        # return the expected API response.
+        await produce_request_response(meta, custom_settings=custom_settings)
+    except Exception:
+        pass
 
-        # What we're interested in is the Request call in the API
-        request_call = [c for c in mock_client.mock_calls if "request_raw(" in str(c)]
+    # What we're interested in is the Request call in the API
+    request_call = [c for c in mock_client.mock_calls if "request_raw(" in str(c)]
 
-        if not use_zyte_api:
-            assert request_call == []
-            return
+    if not use_zyte_api:
+        assert request_call == []
+        return
 
-        elif not request_call:
-            pytest.fail("The client's request_raw() method was not called.")
+    elif not request_call:
+        pytest.fail("The client's request_raw() method was not called.")
 
-        args_used = request_call[0].args[0]
-        args_used.pop("url")
+    args_used = request_call[0].args[0]
+    args_used.pop("url")
 
-        assert args_used == expected
+    assert args_used == expected
 
-    @pytest.mark.parametrize(
-        "meta, api_relevant",
-        [
-            ({"zyte_api": {"waka": True}}, True),
-            ({"zyte_api": True}, True),
-            ({"zyte_api": {"browserHtml": True}}, True),
-            ({"zyte_api": {}}, True),
-            ({"zyte_api": None}, False),
-            ({"randomParameter": True}, False),
-            ({}, False),
-            (None, False),
-        ],
-    )
-    @pytest.mark.asyncio
-    async def test_coro_handling(
-        self, meta: Dict[str, Dict[str, Any]], api_relevant: bool
-    ):
-        custom_settings = {"ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True}}
-        with MockServer() as server:
-            async with make_handler({}, server.urljoin("/")) as handler:
-                req = Request(
-                    "http://example.com",
-                    method="POST",
-                    meta=meta,
-                )
-                handler._zyte_api_default_params = custom_settings
-                if api_relevant:
-                    coro = handler.download_request(req, Spider("test"))
-                    assert not iscoroutine(coro)
-                    assert isinstance(coro, Deferred)
-                else:
-                    # Non-API requests won't get into handle, but run HTTPDownloadHandler.download_request instead
-                    # But because they're Deferred - they won't run because event loop is closed
-                    with pytest.raises(RuntimeError, match="Event loop is closed"):
-                        handler.download_request(req, Spider("test"))
 
-    @pytest.mark.parametrize(
-        "meta, server_path, exception_type, exception_text",
-        [
-            (
-                {"zyte_api": {"echoData": Request("http://test.com")}},
-                "/",
-                IgnoreRequest,
-                "Got an error when processing Zyte API request (http://example.com): "
-                "Object of type Request is not JSON serializable",
-            ),
-            (
-                {"zyte_api": {"browserHtml": True}},
-                "/exception/",
-                IgnoreRequest,
-                "Got Zyte API error (400) while processing URL (http://example.com): "
-                "Bad Request",
-            ),
-        ],
-    )
-    @pytest.mark.asyncio
-    async def test_exceptions(
-        self,
-        caplog: LogCaptureFixture,
-        meta: Dict[str, Dict[str, Any]],
-        server_path: str,
-        exception_type: Exception,
-        exception_text: str,
-    ):
-        with MockServer() as server:
-            async with make_handler({}, server.urljoin(server_path)) as handler:
-                req = Request("http://example.com", method="POST", meta=meta)
-                api_params = handler._prepare_api_params(req)
+@pytest.mark.parametrize(
+    "meta",
+    [
+        {"zyte_api": {"waka": True}},
+        {"zyte_api": True},
+        {"zyte_api": {"browserHtml": True}},
+        {"zyte_api": {}},
+        {"zyte_api": None},
+        {"randomParameter": True},
+        {},
+        None,
+    ],
+)
+@ensureDeferred
+async def test_coro_handling(meta: Dict[str, Dict[str, Any]]):
+    custom_settings = {"ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True}}
+    with MockServer() as server:
+        async with make_handler({}, server.urljoin("/")) as handler:
+            req = Request(
+                "https://toscrape.com",
+                meta=meta,
+            )
+            handler._zyte_api_default_params = custom_settings
+            coro = handler.download_request(req, Spider("test"))
+            assert not iscoroutine(coro)
+            assert isinstance(coro, Deferred)
 
-                with pytest.raises(exception_type):  # NOQA
-                    await handler._download_request(
-                        api_params, req, Spider("test")
-                    )  # NOQA
-                assert exception_text in caplog.text
 
-    @pytest.mark.parametrize(
-        "job_id",
-        ["547773/99/6"],
-    )
-    @pytest.mark.asyncio
-    async def test_job_id(self, job_id):
-        with MockServer() as server:
-            async with make_handler({"JOB": job_id}, server.urljoin("/")) as handler:
-                req = Request(
-                    "http://example.com",
-                    method="POST",
-                    meta={"zyte_api": {"browserHtml": True}},
-                )
-                api_params = handler._prepare_api_params(req)
-                resp = await handler._download_request(
+@ensureDeferred
+@pytest.mark.parametrize(
+    "meta, server_path, exception_type, exception_text",
+    [
+        (
+            {"zyte_api": {"echoData": Request("http://test.com")}},
+            "/",
+            IgnoreRequest,
+            "Got an error when processing Zyte API request (http://example.com): "
+            "Object of type Request is not JSON serializable",
+        ),
+        (
+            {"zyte_api": {"browserHtml": True}},
+            "/exception/",
+            IgnoreRequest,
+            "Got Zyte API error (400) while processing URL (http://example.com): "
+            "Bad Request",
+        ),
+    ],
+)
+async def test_exceptions(
+    caplog: LogCaptureFixture,
+    meta: Dict[str, Dict[str, Any]],
+    server_path: str,
+    exception_type: Exception,
+    exception_text: str,
+):
+    with MockServer() as server:
+        async with make_handler({}, server.urljoin(server_path)) as handler:
+            req = Request("http://example.com", method="POST", meta=meta)
+            api_params = handler._prepare_api_params(req)
+
+            with pytest.raises(exception_type):  # NOQA
+                await handler._download_request(
                     api_params, req, Spider("test")
                 )  # NOQA
+            assert exception_text in caplog.text
 
-            assert resp.request is req
-            assert resp.url == req.url
-            assert resp.status == 200
-            assert "zyte-api" in resp.flags
-            assert resp.body == f"<html>{job_id}</html>".encode("utf8")
+
+@pytest.mark.parametrize(
+    "job_id",
+    ["547773/99/6"],
+)
+@ensureDeferred
+async def test_job_id(job_id):
+    with MockServer() as server:
+        async with make_handler({"JOB": job_id}, server.urljoin("/")) as handler:
+            req = Request(
+                "http://example.com",
+                method="POST",
+                meta={"zyte_api": {"browserHtml": True}},
+            )
+            api_params = handler._prepare_api_params(req)
+            resp = await handler._download_request(
+                api_params, req, Spider("test")
+            )  # NOQA
+
+        assert resp.request is req
+        assert resp.url == req.url
+        assert resp.status == 200
+        assert "zyte-api" in resp.flags
+        assert resp.body == f"<html>{job_id}</html>".encode("utf8")
 
 
 def test_api_key_presence():

--- a/tests/test_api_requests.py
+++ b/tests/test_api_requests.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 import pytest
 from _pytest.logging import LogCaptureFixture  # NOQA
-from pytest_twisted import ensureDeferred, inlineCallbacks
+from pytest_twisted import ensureDeferred
 from scrapy import Request, Spider
 from scrapy.exceptions import IgnoreRequest, NotConfigured, NotSupported
 from scrapy.http import Response, TextResponse

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -1,5 +1,4 @@
 import pytest
-from scrapy.utils.reactor import install_reactor
 from scrapy.utils.test import get_crawler
 from twisted.internet.asyncioreactor import AsyncioSelectorReactor
 from zyte_api.aio.client import AsyncClient

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -69,7 +69,7 @@ def test_concurrency_configuration(concurrency):
         (
             UNSET,
             "",
-            "",
+            NotConfigured,
         ),
         (
             "",
@@ -79,7 +79,7 @@ def test_concurrency_configuration(concurrency):
         (
             "a",
             "",
-            "",
+            "a",
         ),
         (
             UNSET,

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -1,35 +1,27 @@
+from inspect import isclass
+
 import pytest
+from scrapy.exceptions import NotConfigured
+from scrapy.utils.misc import create_instance
 from scrapy.utils.test import get_crawler
-from twisted.internet.asyncioreactor import AsyncioSelectorReactor
 from zyte_api.aio.client import AsyncClient
+from zyte_api.constants import API_URL
 
 from scrapy_zyte_api.handler import ScrapyZyteAPIDownloadHandler
-
-
-_API_KEY = 'a'
-
-_BASE_SETTINGS = {
-    'DOWNLOAD_HANDLERS': {
-        'http': 'scrapy_zyte_api.handler.ScrapyZyteAPIDownloadHandler',
-        'https': 'scrapy_zyte_api.handler.ScrapyZyteAPIDownloadHandler'
-    },
-    'ZYTE_API_KEY': _API_KEY,
-    'TWISTED_REACTOR': AsyncioSelectorReactor,
-}
-_DEFAULT_CLIENT_CONCURRENCY = AsyncClient(api_key=_API_KEY).n_conn
+from . import DEFAULT_CLIENT_CONCURRENCY, set_env, SETTINGS, UNSET
 
 
 @pytest.mark.parametrize(
     'concurrency',
     (
         1,
-        _DEFAULT_CLIENT_CONCURRENCY,
-        _DEFAULT_CLIENT_CONCURRENCY + 1,
+        DEFAULT_CLIENT_CONCURRENCY,
+        DEFAULT_CLIENT_CONCURRENCY + 1,
     ),
 )
-def test_concurrency(concurrency):
+def test_concurrency_configuration(concurrency):
     settings = {
-        **_BASE_SETTINGS,
+        **SETTINGS,
         'CONCURRENT_REQUESTS': concurrency,
     }
     crawler = get_crawler(settings_dict=settings)
@@ -39,3 +31,139 @@ def test_concurrency(concurrency):
     )
     assert handler._client.n_conn == concurrency
     assert handler._session.connector.limit == concurrency
+
+
+@pytest.mark.parametrize(
+    "env_var,setting,expected",
+    (
+        (
+            UNSET,
+            UNSET,
+            NotConfigured,
+        ),
+        (
+            "",
+            UNSET,
+            "",
+        ),
+        (
+            "a",
+            UNSET,
+            "a",
+        ),
+        (
+            UNSET,
+            None,
+            NotConfigured,
+        ),
+        (
+            "",
+            None,
+            "",
+        ),
+        (
+            "a",
+            None,
+            "a",
+        ),
+        (
+            UNSET,
+            "",
+            "",
+        ),
+        (
+            "",
+            "",
+            "",
+        ),
+        (
+            "a",
+            "",
+            "",
+        ),
+        (
+            UNSET,
+            "b",
+            "b",
+        ),
+        (
+            "",
+            "b",
+            "b",
+        ),
+        (
+            "a",
+            "b",
+            "b",
+        ),
+    ),
+)
+def test_api_key(env_var, setting, expected):
+    env = {}
+    if env_var is not UNSET:
+        env["ZYTE_API_KEY"] = env_var
+    settings = {}
+    if setting is not UNSET:
+        settings["ZYTE_API_KEY"] = setting
+    with set_env(**env):
+        crawler = get_crawler(settings_dict=settings)
+
+        def build_hander():
+            return create_instance(
+                ScrapyZyteAPIDownloadHandler,
+                settings=None,
+                crawler=crawler,
+            )
+
+        if isclass(expected) and issubclass(expected, Exception):
+            with pytest.raises(expected):
+                handler = build_hander()
+        else:
+            handler = build_hander()
+            assert handler._client.api_key == expected
+
+
+@pytest.mark.parametrize(
+    "setting,expected",
+    (
+        (
+            UNSET,
+            API_URL,
+        ),
+        (
+            None,
+            API_URL,
+        ),
+        (
+            "",
+            API_URL,
+        ),
+        (
+            "a",
+            "a",
+        ),
+        (
+            "https://api.example.com",
+            "https://api.example.com",
+        ),
+    ),
+)
+def test_api_url(setting, expected):
+    settings = {"ZYTE_API_KEY": "a"}
+    if setting is not UNSET:
+        settings["ZYTE_API_URL"] = setting
+    crawler = get_crawler(settings_dict=settings)
+    handler = create_instance(
+        ScrapyZyteAPIDownloadHandler,
+        settings=None,
+        crawler=crawler,
+    )
+    assert handler._client.api_url == expected
+
+
+def test_custom_client():
+    client = AsyncClient(api_key="a", api_url="b")
+    crawler = get_crawler()
+    handler = ScrapyZyteAPIDownloadHandler(crawler.settings, crawler, client)
+    assert handler._client == client
+    assert handler._client != AsyncClient(api_key="a", api_url="b")

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -1,0 +1,42 @@
+import pytest
+from scrapy.utils.reactor import install_reactor
+from scrapy.utils.test import get_crawler
+from twisted.internet.asyncioreactor import AsyncioSelectorReactor
+from zyte_api.aio.client import AsyncClient
+
+from scrapy_zyte_api.handler import ScrapyZyteAPIDownloadHandler
+
+
+_API_KEY = 'a'
+
+_BASE_SETTINGS = {
+    'DOWNLOAD_HANDLERS': {
+        'http': 'scrapy_zyte_api.handler.ScrapyZyteAPIDownloadHandler',
+        'https': 'scrapy_zyte_api.handler.ScrapyZyteAPIDownloadHandler'
+    },
+    'ZYTE_API_KEY': _API_KEY,
+    'TWISTED_REACTOR': AsyncioSelectorReactor,
+}
+_DEFAULT_CLIENT_CONCURRENCY = AsyncClient(api_key=_API_KEY).n_conn
+
+
+@pytest.mark.parametrize(
+    'concurrency',
+    (
+        1,
+        _DEFAULT_CLIENT_CONCURRENCY,
+        _DEFAULT_CLIENT_CONCURRENCY + 1,
+    ),
+)
+def test_concurrency(concurrency):
+    settings = {
+        **_BASE_SETTINGS,
+        'CONCURRENT_REQUESTS': concurrency,
+    }
+    crawler = get_crawler(settings_dict=settings)
+    handler = ScrapyZyteAPIDownloadHandler(
+        settings=crawler.settings,
+        crawler=crawler,
+    )
+    assert handler._client.n_conn == concurrency
+    assert handler._session.connector.limit == concurrency

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ commands =
     --cov-report=xml \
     --cov=scrapy_zyte_api \
     --junitxml=test-results/junit.xml \
+    --reactor=asyncio \
     {posargs:scrapy_zyte_api tests}
 
 [testenv:mypy]


### PR DESCRIPTION
Fixes https://github.com/scrapy-plugins/scrapy-zyte-api/issues/23

I thought about warning if a custom `client` is passed with an `n_conn` different than the one in `CONCURRENT_REQUESTS`, but since that could be done on purpose and providing a setting to silence that warning seemed overkill, I decided against it.

To do:

- [x] Figure out the issue with the 2 failing tests.