### PR TITLE
update dep requirement: scrapy>=2.6.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+TBD
+---
+
+* Update minimum requirement: ``scrapy>=2.6.0``.
+
 
 0.2.0 (2022-05-31)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Requirements
 ------------
 
 * Python 3.7+
-* Scrapy
+* Scrapy 2.6+
 
 Installation
 ------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-scrapy>=2.5.1
+scrapy>=2.6.1
 zyte-api>=0.1.2
 twisted>=21.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-scrapy>=2.6.1
 zyte-api>=0.1.2
 twisted>=21.7.0

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setuptools.setup(
     author_email="info@zyte.com",
     url="https://github.com/scrapy-plugins/scrapy-zyte-api",
     packages=["scrapy_zyte_api"],
-    install_requires=["zyte-api>=0.1.2"],
+    install_requires=["zyte-api>=0.1.2", "scrapy>=2.6.0"],
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",


### PR DESCRIPTION
Some users encounter problems like the one below when using the old version of Scrapy:
```
ERROR: <twisted.python.failure.Failure scrapy.exceptions.NotSupported: Unsupported URL scheme 'https': type object 'TextResponse' has no attribute 'attributes'>
```

It stems from using the new `Response.attributes` of Scrapy 2.6.

I'm proposing to require users to have a minimum of `scrapy>=2.6.0` to be able to use it.

Fixes https://github.com/scrapy-plugins/scrapy-zyte-api/issues/22