### PR TITLE
Expose python-zyte-api stats to Scrapy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,16 @@
 Changes
 =======
 
+To be released
+--------------
+
+* Stats from python-zyte-api_ are now copied into Scrapy stats. The
+  ``scrapy-zyte-api/request_count`` stat has been renamed to
+  ``scrapy-zyte-api/input_queries`` accordingly.
+
+.. _python-zyte-api: https://github.com/zytedata/python-zyte-api
+
+
 0.3.0 (2022-07-22)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,11 +4,13 @@ Changes
 To be released
 --------------
 
-* Stats from python-zyte-api_ are now copied into Scrapy stats. The
-  ``scrapy-zyte-api/request_count`` stat has been renamed to
-  ``scrapy-zyte-api/input_queries`` accordingly.
+* Requires zyte-api_ ≥ 0.3.0.
 
-.. _python-zyte-api: https://github.com/zytedata/python-zyte-api
+* Stats from zyte-api are now copied into Scrapy stats. The
+  ``scrapy-zyte-api/request_count`` stat has been renamed to
+  ``scrapy-zyte-api/processed`` accordingly.
+
+.. _zyte-api: https://github.com/zytedata/python-zyte-api
 
 
 0.3.0 (2022-07-22)

--- a/README.rst
+++ b/README.rst
@@ -279,3 +279,10 @@ subclass RetryFactory_ as follows::
 .. _python-zyte-api: https://github.com/zytedata/python-zyte-api
 .. _RetryFactory: https://github.com/zytedata/python-zyte-api/blob/main/zyte_api/aio/retry.py
 .. _tenacity.AsyncRetrying: https://tenacity.readthedocs.io/en/latest/api.html#tenacity.AsyncRetrying
+
+
+Stats
+-----
+
+Stats from python-zyte-api_ are exposed as Scrapy stats with the
+``scrapy-zyte-api`` prefix.

--- a/scrapy_zyte_api/handler.py
+++ b/scrapy_zyte_api/handler.py
@@ -92,14 +92,22 @@ class ScrapyZyteAPIDownloadHandler(HTTPDownloadHandler):
             '429',
             'attempts',
             'errors',
-            'extracted_queries',
             'fatal_errors',
-            'input_queries',
-            'results',
+            'processed',
+            'success',
         ):
             self._stats.set_value(
                 f"{prefix}/{stat}",
                 getattr(self._client.agg_stats, f"n_{stat}"),
+            )
+        for stat in (
+            'error_ratio',
+            'success_ratio',
+            'throttle_ratio',
+        ):
+            self._stats.set_value(
+                f"{prefix}/{stat}",
+                getattr(self._client.agg_stats, stat)(),
             )
         for source, target in (
             ('connect', 'connection'),

--- a/scrapy_zyte_api/handler.py
+++ b/scrapy_zyte_api/handler.py
@@ -120,7 +120,6 @@ class ScrapyZyteAPIDownloadHandler(HTTPDownloadHandler):
                     value,
                 )
 
-
     async def _download_request(
         self, api_params: dict, request: Request, spider: Spider
     ) -> Optional[Union[ZyteAPITextResponse, ZyteAPIResponse]]:

--- a/scrapy_zyte_api/handler.py
+++ b/scrapy_zyte_api/handler.py
@@ -146,8 +146,8 @@ class ScrapyZyteAPIDownloadHandler(HTTPDownloadHandler):
                 f"Got an error when processing Zyte API request ({request.url}): {er}"
             )
             raise IgnoreRequest()
-
-        self._update_stats()
+        finally:
+            self._update_stats()
 
         return _process_response(api_response, request)
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setuptools.setup(
     author_email="info@zyte.com",
     url="https://github.com/scrapy-plugins/scrapy-zyte-api",
     packages=["scrapy_zyte_api"],
-    install_requires=["zyte-api>=0.1.2", "scrapy>=2.6.0"],
+    install_requires=["zyte-api>=0.3.0", "scrapy>=2.6.0"],
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -226,15 +226,34 @@ async def test_stats():
             request = Request("https://example.com", meta=meta)
             await handler.download_request(request, None)
 
+            assert set(scrapy_stats.get_stats()) == {
+                f'scrapy-zyte-api/{stat}'
+                for stat in (
+                    '429',
+                    'attempts',
+                    'error_ratio',
+                    'errors',
+                    'fatal_errors',
+                    'mean_connection_seconds',
+                    'mean_response_seconds',
+                    'processed',
+                    'status_codes/200',
+                    'success_ratio',
+                    'success',
+                    'throttle_ratio',
+                )
+            }
             for suffix, value in (
                 ('429', 0),
                 ('attempts', 1),
+                ('error_ratio', 0.0),
                 ('errors', 0),
-                ('extracted_queries', 1),
                 ('fatal_errors', 0),
-                ('input_queries', 1),
-                ('results', 1),
+                ('processed', 1),
                 ('status_codes/200', 1),
+                ('success_ratio', 1.0),
+                ('success', 1),
+                ('throttle_ratio', 0.0),
             ):
                 stat = f"scrapy-zyte-api/{suffix}"
                 assert scrapy_stats.get_value(stat) == value

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -222,15 +222,13 @@ async def test_stats():
             scrapy_stats = handler._crawler.stats
             assert scrapy_stats.get_stats() == {}
 
-            client_stats = handler._client.agg_stats
-            client_stats.n_attempts += 1
-
             meta = {"zyte_api": {"foo": "bar"}}
             request = Request("https://example.com", meta=meta)
             await handler.download_request(request, None)
 
             for suffix, value in (
                 ('429', 0),
+                ('attempts', 1),
                 ('errors', 0),
                 ('extracted_queries', 1),
                 ('fatal_errors', 0),


### PR DESCRIPTION
Resolves #31

I am slightly worried about the impact that copying stats (specially means) can have on CPU-bound spiders.

I first tried to make it so that stats would be copied every N seconds with reactor.callLater, and finally when the download handler closes. To my surprise, that did not work when doing a manual test. As far as I can tell, the `close` method of a download handler is never called, the downloader seems to only call `download_request`.

So I went for copying after every request download.

Do you think this is OK? Should we consider skipping the mean stats from the copy?

To do:
- [x] Agree on an approach
- [x] Add tests