### PR TITLE
Improve error messages in logs - add error type. Also, simplify the implementation.

### DIFF
--- a/scrapy_zyte_api/handler.py
+++ b/scrapy_zyte_api/handler.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from typing import Any, Dict, Generator, Optional, Union
 

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -68,8 +68,13 @@ class DefaultResource(LeafResource):
 
         if "browserHtml" in request_data:
             if "httpResponseBody" in request_data:
-                request.setResponseCode(400)
-                return json.dumps(response_data).encode()
+                request.setResponseCode(422)
+                return json.dumps({
+                    "type": "/request/unprocessable",
+                    "title": "Unprocessable Request",
+                    "status": 422,
+                    "detail": "Incompatible parameters were found in the request."
+                }).encode()
             response_data["browserHtml"] = html
         elif "httpResponseBody" in request_data:
             base64_html = b64encode(html.encode()).decode()

--- a/tests/test_api_requests.py
+++ b/tests/test_api_requests.py
@@ -208,8 +208,8 @@ async def test_coro_handling(meta: Dict[str, Dict[str, Any]]):
         (
             {"zyte_api": {"browserHtml": True, "httpResponseBody": True}},
             IgnoreRequest,
-            "Got Zyte API error (400) while processing URL (http://example.com): "
-            "Bad Request",
+            "Got Zyte API error (status=422, type='/request/unprocessable') while processing URL (http://example.com): "
+            "Incompatible parameters were found in the request.",
         ),
     ],
 )


### PR DESCRIPTION
In this PR I've added error.type to the logs. Messages now look like this:

> ERROR: Got Zyte API error (status=451, type='/download/domain-forbidden') while processing URL (https://example.com/): Extraction for the domain is forbidden.

Previously, it was this:

> ERROR: Got Zyte API error (451) while processing URL (https://example.com/): Extraction for the domain is forbidden.

The implementation is also simplified. I think there is no need to be as defensive as we were before: error class is known, I don't see why various attributes won't be available.