### PR TITLE
tests cleanup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+
+@pytest.fixture(scope='session')
+def mockserver():
+    from .mockserver import MockServer
+    with MockServer() as server:
+        yield server

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -25,12 +25,11 @@ def get_ephemeral_port():
 
 
 @ensureDeferred
-async def produce_request_response(meta, settings=None):
-    with MockServer() as server:
-        async with server.make_handler(settings) as handler:
-            req = Request(server.urljoin("/"), meta=meta)
-            resp = await handler.download_request(req, None)
-            return req, resp
+async def produce_request_response(mockserver, meta, settings=None):
+    async with mockserver.make_handler(settings) as handler:
+        req = Request(mockserver.urljoin("/"), meta=meta)
+        resp = await handler.download_request(req, None)
+        return req, resp
 
 
 class LeafResource(Resource):

--- a/tests/test_api_requests.py
+++ b/tests/test_api_requests.py
@@ -186,12 +186,15 @@ async def test_coro_handling(meta: Dict[str, Dict[str, Any]], mockserver):
     settings = {"ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True}}
     async with mockserver.make_handler(settings) as handler:
         req = Request(
-            "https://toscrape.com",
+            # this should really be a URL to a website, not to the API server,
+            # but API server URL works ok
+            mockserver.urljoin("/"),
             meta=meta,
         )
-        coro = handler.download_request(req, Spider("test"))
-        assert not iscoroutine(coro)
-        assert isinstance(coro, Deferred)
+        dfd = handler.download_request(req, Spider("test"))
+        assert not iscoroutine(dfd)
+        assert isinstance(dfd, Deferred)
+        await dfd
 
 
 @ensureDeferred

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -15,7 +15,6 @@ from zyte_api.constants import API_URL
 from scrapy_zyte_api.handler import ScrapyZyteAPIDownloadHandler
 
 from . import DEFAULT_CLIENT_CONCURRENCY, SETTINGS, UNSET, make_handler, set_env
-from .mockserver import MockServer
 
 
 @pytest.mark.parametrize(
@@ -216,49 +215,48 @@ async def test_retry_policy(
 
 
 @ensureDeferred
-async def test_stats():
-    with MockServer() as server:
-        async with make_handler({}, server.urljoin("/")) as handler:
-            scrapy_stats = handler._crawler.stats
-            assert scrapy_stats.get_stats() == {}
+async def test_stats(mockserver):
+    async with make_handler({}, mockserver.urljoin("/")) as handler:
+        scrapy_stats = handler._crawler.stats
+        assert scrapy_stats.get_stats() == {}
 
-            meta = {"zyte_api": {"foo": "bar"}}
-            request = Request("https://example.com", meta=meta)
-            await handler.download_request(request, None)
+        meta = {"zyte_api": {"foo": "bar"}}
+        request = Request("https://example.com", meta=meta)
+        await handler.download_request(request, None)
 
-            assert set(scrapy_stats.get_stats()) == {
-                f'scrapy-zyte-api/{stat}'
-                for stat in (
-                    '429',
-                    'attempts',
-                    'error_ratio',
-                    'errors',
-                    'fatal_errors',
-                    'mean_connection_seconds',
-                    'mean_response_seconds',
-                    'processed',
-                    'status_codes/200',
-                    'success_ratio',
-                    'success',
-                    'throttle_ratio',
-                )
-            }
-            for suffix, value in (
-                ('429', 0),
-                ('attempts', 1),
-                ('error_ratio', 0.0),
-                ('errors', 0),
-                ('fatal_errors', 0),
-                ('processed', 1),
-                ('status_codes/200', 1),
-                ('success_ratio', 1.0),
-                ('success', 1),
-                ('throttle_ratio', 0.0),
-            ):
-                stat = f"scrapy-zyte-api/{suffix}"
-                assert scrapy_stats.get_value(stat) == value
-            for name in ('connection', 'response'):
-                stat = f"scrapy-zyte-api/mean_{name}_seconds"
-                value = scrapy_stats.get_value(stat)
-                assert isinstance(value, float)
-                assert value > 0.0
+        assert set(scrapy_stats.get_stats()) == {
+            f'scrapy-zyte-api/{stat}'
+            for stat in (
+                '429',
+                'attempts',
+                'error_ratio',
+                'errors',
+                'fatal_errors',
+                'mean_connection_seconds',
+                'mean_response_seconds',
+                'processed',
+                'status_codes/200',
+                'success_ratio',
+                'success',
+                'throttle_ratio',
+            )
+        }
+        for suffix, value in (
+            ('429', 0),
+            ('attempts', 1),
+            ('error_ratio', 0.0),
+            ('errors', 0),
+            ('fatal_errors', 0),
+            ('processed', 1),
+            ('status_codes/200', 1),
+            ('success_ratio', 1.0),
+            ('success', 1),
+            ('throttle_ratio', 0.0),
+        ):
+            stat = f"scrapy-zyte-api/{suffix}"
+            assert scrapy_stats.get_value(stat) == value
+        for name in ('connection', 'response'):
+            stat = f"scrapy-zyte-api/mean_{name}_seconds"
+            value = scrapy_stats.get_value(stat)
+            assert isinstance(value, float)
+            assert value > 0.0


### PR DESCRIPTION
1. MockServer is now used via fixtures. This speeds up tests greatly (~10x?), because mockserver is no longer restarted for every test.
2. Fixed a case where a test was accessing a remote website (toscrape.com)
3. Fixed a case where a test was not awaiting for a Deferred