### PR TITLE
Support transparent mapping of regular requests to Zyte Data API requests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -116,8 +116,12 @@ and ``scrapy.http.TextResponse``.
 If multiple requests target the same URL with different Zyte Data API
 parameters, pass ``dont_filter=True`` to ``Request``.
 
+
+.. _default-params:
+
 Setting default parameters
 --------------------------
+
 Often the same configuration needs to be used for all Zyte API requests.
 For example, all requests may need to set the same geolocation, or
 the spider only uses ``browserHtml`` requests.
@@ -133,13 +137,7 @@ following in the ``settings.py`` file or `any other settings within Scrapy
         "geolocation": "US",
     }
 
-
-``ZYTE_API_DEFAULT_PARAMS`` works if the ``zyte_api``
-key in `Request.meta <https://docs.scrapy.org/en/latest/topics/request-response.html#scrapy.http.Request.meta>`_
-is set, i.e. having ``ZYTE_API_DEFAULT_PARAMS`` doesn't make all requests
-to go through Zyte Data API. Parameters in ``ZYTE_API_DEFAULT_PARAMS`` are 
-merged with parameters set via the ``zyte_api`` meta key, with the values in 
-meta taking priority.
+For example:
 
 .. code-block:: python
 
@@ -191,49 +189,36 @@ meta taking priority.
             #     'download_slot': 'quotes.toscrape.com'
             # }
 
-There is a shortcut, in case a request uses the same parameters as
-defined in the ``ZYTE_API_DEFAULT_PARAMS`` setting, without any further
-customization - the ``zyte_api`` meta key can be set to ``True`` or ``{}``:
+``ZYTE_API_DEFAULT_PARAMS`` does not make requests automatically go through
+Zyte Data API. See :ref:`enabled`.
 
-.. code-block:: python
-
-    import scrapy
+Parameters in ``ZYTE_API_DEFAULT_PARAMS`` are merged with parameters set via
+the ``zyte_api`` meta key, with the values in meta taking priority.
 
 
-    class SampleQuotesSpider(scrapy.Spider):
-        name = "sample_quotes"
+.. _enabled:
 
-        custom_settings = {
-            "ZYTE_API_DEFAULT_PARAMS": {
-                "browserHtml": True,
-            }
-        }
+Controlling which requests go through Zyte Data API
+---------------------------------------------------
 
-        def start_requests(self):
-            yield scrapy.Request(
-                url="http://quotes.toscrape.com/",
-                callback=self.parse,
-                meta={"zyte_api": True},
-            )
+The ``ZYTE_API_ENABLED`` setting can be used to control whether all, none, or
+some requests go through Zyte Data API. It supports the following values:
 
-        def parse(self, response):
-            yield {"URL": response.url, "HTML": response.body}
+-   ``None`` (default): only requests where the ``zyte_api`` key in
+    Request.meta_ is set to ``True`` or set to a dictionary go through Zyte
+    Data API.
 
-            print(response.raw_api_response)
-            # {
-            #     'url': 'https://quotes.toscrape.com/',
-            #     'statusCode': 200,
-            #     'browserHtml': '<html> ... </html>',
-            # }
+    .. _Request.meta: https://docs.scrapy.org/en/latest/topics/request-response.html#scrapy.http.Request.meta
 
-            print(response.request.meta)
-            # {
-            #     'zyte_api': {
-            #         'browserHtml': True,
-            #     },
-            #     'download_timeout': 180.0,
-            #     'download_slot': 'quotes.toscrape.com'
-            # }
+-   ``True``: all requests go through Zyte Data API, unless the ``zyte_api``
+    key in Request.meta_ is set to ``False``.
+
+-   ``False``: disables this plugin.
+
+Zyte Data API requests need parameters. You must either set those parameters in
+the ``zyte_api`` metadata key of every request or :ref:`set default parameters
+<default-params>`.
+
 
 Customizing the retry policy
 ----------------------------

--- a/README.rst
+++ b/README.rst
@@ -206,14 +206,16 @@ By default, only requests where the ``zyte_api`` key in Request.meta_ is set to
 
 .. _Request.meta: https://docs.scrapy.org/en/latest/topics/request-response.html#scrapy.http.Request.meta
 
-Set the ``ZYTE_API_ALL`` setting to ``True`` to make all requests go through
-Zyte Data API unless the ``zyte_api`` key in Request.meta_ is set to ``False``.
+Set the ``ZYTE_API_ON_ALL_REQUESTS`` setting to ``True`` to make all requests
+go through Zyte Data API unless the ``zyte_api`` key in Request.meta_ is set to
+``False``. ``ZYTE_API_ON_ALL_REQUESTS`` is ``False`` by default.
 
 Zyte Data API requests need parameters. If you set the ``zyte_api`` key in
-Request.meta_ or the ``ZYTE_API_ALL`` setting to ``True``, you must also
-:ref:`set default parameters <default-params>`.
+Request.meta_ or the ``ZYTE_API_ON_ALL_REQUESTS`` setting to ``True``, you must
+also :ref:`set default parameters <default-params>`.
 
 Set the ``ZYTE_API_ENABLED`` setting to ``False`` to disable this plugin.
+``ZYTE_API_ENABLED`` is ``True`` by default.
 
 
 Customizing the retry policy

--- a/README.rst
+++ b/README.rst
@@ -201,23 +201,19 @@ the ``zyte_api`` meta key, with the values in meta taking priority.
 Controlling which requests go through Zyte Data API
 ---------------------------------------------------
 
-The ``ZYTE_API_ENABLED`` setting can be used to control whether all, none, or
-some requests go through Zyte Data API. It supports the following values:
+By default, only requests where the ``zyte_api`` key in Request.meta_ is set to
+``True`` or set to a dictionary go through Zyte Data API.
 
--   ``None`` (default): only requests where the ``zyte_api`` key in
-    Request.meta_ is set to ``True`` or set to a dictionary go through Zyte
-    Data API.
+.. _Request.meta: https://docs.scrapy.org/en/latest/topics/request-response.html#scrapy.http.Request.meta
 
-    .. _Request.meta: https://docs.scrapy.org/en/latest/topics/request-response.html#scrapy.http.Request.meta
+Set the ``ZYTE_API_ALL`` setting to ``True`` to make all requests go through
+Zyte Data API unless the ``zyte_api`` key in Request.meta_ is set to ``False``.
 
--   ``True``: all requests go through Zyte Data API, unless the ``zyte_api``
-    key in Request.meta_ is set to ``False``.
+Zyte Data API requests need parameters. If you set the ``zyte_api`` key in
+Request.meta_ or the ``ZYTE_API_ALL`` setting to ``True``, you must also
+:ref:`set default parameters <default-params>`.
 
--   ``False``: disables this plugin.
-
-Zyte Data API requests need parameters. You must either set those parameters in
-the ``zyte_api`` metadata key of every request or :ref:`set default parameters
-<default-params>`.
+Set the ``ZYTE_API_ENABLED`` setting to ``False`` to disable this plugin.
 
 
 Customizing the retry policy

--- a/scrapy_zyte_api/handler.py
+++ b/scrapy_zyte_api/handler.py
@@ -26,11 +26,8 @@ class ScrapyZyteAPIDownloadHandler(HTTPDownloadHandler):
         self, settings: Settings, crawler: Crawler, client: AsyncClient = None
     ):
         super().__init__(settings=settings, crawler=crawler)
-        enabled = settings.get("ZYTE_API_ENABLED")
-        if enabled is False:
+        if not settings.getbool("ZYTE_API_ENABLED", True):
             raise NotConfigured
-        self._enabled_by_default = enabled or False
-
         if not client:
             try:
                 client = AsyncClient(
@@ -62,6 +59,7 @@ class ScrapyZyteAPIDownloadHandler(HTTPDownloadHandler):
         self._zyte_api_default_params = settings.getdict("ZYTE_API_DEFAULT_PARAMS")
         self._session = create_session(connection_pool_size=self._client.n_conn)
         self._retry_policy = settings.get("ZYTE_API_RETRY_POLICY")
+        self._all = settings.getbool("ZYTE_API_ALL")
 
     def download_request(self, request: Request, spider: Spider) -> Deferred:
         api_params = self._prepare_api_params(request)
@@ -72,7 +70,7 @@ class ScrapyZyteAPIDownloadHandler(HTTPDownloadHandler):
         return super().download_request(request, spider)
 
     def _prepare_api_params(self, request: Request) -> Optional[dict]:
-        meta_params = request.meta.get("zyte_api", self._enabled_by_default)
+        meta_params = request.meta.get("zyte_api", self._all)
         if meta_params is False:
             return None
         if not meta_params and meta_params != {}:

--- a/scrapy_zyte_api/handler.py
+++ b/scrapy_zyte_api/handler.py
@@ -59,7 +59,7 @@ class ScrapyZyteAPIDownloadHandler(HTTPDownloadHandler):
         self._zyte_api_default_params = settings.getdict("ZYTE_API_DEFAULT_PARAMS")
         self._session = create_session(connection_pool_size=self._client.n_conn)
         self._retry_policy = settings.get("ZYTE_API_RETRY_POLICY")
-        self._all = settings.getbool("ZYTE_API_ALL")
+        self._on_all_requests = settings.getbool("ZYTE_API_ON_ALL_REQUESTS")
 
     def download_request(self, request: Request, spider: Spider) -> Deferred:
         api_params = self._prepare_api_params(request)
@@ -70,7 +70,7 @@ class ScrapyZyteAPIDownloadHandler(HTTPDownloadHandler):
         return super().download_request(request, spider)
 
     def _prepare_api_params(self, request: Request) -> Optional[dict]:
-        meta_params = request.meta.get("zyte_api", self._all)
+        meta_params = request.meta.get("zyte_api", self._on_all_requests)
         if meta_params is False:
             return None
         if not meta_params and meta_params != {}:

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -66,7 +66,10 @@ class DefaultResource(LeafResource):
             html = "<html><body>Hello<h1>World!</h1></body></html>"
 
         if "browserHtml" in request_data:
-            if "httpResponseBody" in request_data:
+            if (
+                "httpResponseBody" in request_data
+                and not request_data.get("passThrough")
+            ):
                 request.setResponseCode(422)
                 return json.dumps({
                     "type": "/request/unprocessable",
@@ -75,7 +78,7 @@ class DefaultResource(LeafResource):
                     "detail": "Incompatible parameters were found in the request."
                 }).encode()
             response_data["browserHtml"] = html
-        elif "httpResponseBody" in request_data:
+        if "httpResponseBody" in request_data:
             base64_html = b64encode(html.encode()).decode()
             response_data["httpResponseBody"] = base64_html
 

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -146,10 +146,7 @@ class MockServer:
     async def make_handler(self, settings: dict = None):
         settings = settings or {}
         async with make_handler(settings, self.urljoin("/")) as handler:
-            try:
-                yield handler
-            finally:
-                await handler._close()  # NOQA
+            yield handler
 
 
 def main():

--- a/tests/test_api_requests.py
+++ b/tests/test_api_requests.py
@@ -1,6 +1,6 @@
 import sys
 from asyncio import iscoroutine
-from typing import Any, Dict
+from typing import Any, Dict, List, Literal, Union
 from unittest import mock
 
 import pytest
@@ -9,6 +9,10 @@ from pytest_twisted import ensureDeferred
 from scrapy import Request, Spider
 from scrapy.exceptions import IgnoreRequest, NotSupported
 from scrapy.http import Response, TextResponse
+from scrapy.settings.default_settings import (
+    DEFAULT_REQUEST_HEADERS,
+    USER_AGENT as DEFAULT_USER_AGENT,
+)
 from scrapy.utils.defer import deferred_from_coro
 from scrapy.utils.test import get_crawler
 from twisted.internet.defer import Deferred
@@ -450,3 +454,744 @@ async def test_higher_concurrency():
     assert (
         set(response_indexes[: len(expected_first_indexes)]) == expected_first_indexes
     )
+
+
+@ensureDeferred
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="unittest.mock.AsyncMock")
+@pytest.mark.parametrize(
+    "request_kwargs,settings,expected,warnings",
+    [
+        # Automatic mapping of request parameters to Zyte Data API parameters
+        # is enabled by default, but can be disabled.
+        #
+        # httpResponseBody is set to True if no other main content is
+        # requested.
+        *(
+            (
+                {},
+                settings,
+                {
+                    "httpResponseBody": True,
+                    "httpResponseHeaders": True,
+                },
+                [],
+            )
+            for settings in (
+                {},
+                {"ZYTE_API_AUTOMAP": True},
+            )
+        ),
+        (
+            {},
+            {"ZYTE_API_AUTOMAP": False},
+            False,
+            [],
+        ),
+        *(
+            (
+                {"meta": {"zyte_api": {"a": "b"}}},
+                settings,
+                {
+                    "httpResponseBody": True,
+                    "httpResponseHeaders": True,
+                    "a": "b",
+                },
+                [],
+            )
+            for settings in (
+                {},
+                {"ZYTE_API_AUTOMAP": True},
+            )
+        ),
+        (
+            {"meta": {"zyte_api": {"a": "b"}}},
+            {"ZYTE_API_AUTOMAP": False},
+            {
+                "a": "b",
+            },
+            [],
+        ),
+        # httpResponseBody can be unset through meta. That way, if a new main
+        # output type other than browserHtml and screenshot is implemented in
+        # the future, you can request the new output type and also prevent
+        # httpResponseBody from being enabled automatically, without the need
+        # to disable automated mapping completely.
+        (
+            {"meta": {"zyte_api": {"httpResponseBody": False}}},
+            {},
+            {
+                "httpResponseBody": False,
+            },
+            [],
+        ),
+        (
+            {
+                "meta": {"zyte_api": {"httpResponseBody": False, "newOutputType": True}},
+            },
+            {},
+            {
+                "httpResponseBody": False,
+                "newOutputType": True,
+            },
+            [],
+        ),
+        # httpResponseHeaders is automatically set to True for httpResponseBody
+        # (shown in prior tests) and browserHtml.
+        (
+            {
+                "meta": {"zyte_api": {"browserHtml": True}},
+            },
+            {},
+            {
+                "browserHtml": True,
+                "httpResponseHeaders": True,
+            },
+            [],
+        ),
+        # httpResponseHeaders is not set for screenshot.
+        (
+            {
+                "meta": {"zyte_api": {"screenshot": True}},
+            },
+            {},
+            {
+                "screenshot": True,
+            },
+            [],
+        ),
+        # httpResponseHeaders can be unset through meta.
+        (
+            {
+                "meta": {"zyte_api": {"httpResponseHeaders": False}},
+            },
+            {},
+            {
+                "httpResponseBody": True,
+                "httpResponseHeaders": False,
+            },
+            [],
+        ),
+        (
+            {
+                "meta": {
+                    "zyte_api": {
+                        "browserHtml": True,
+                        "httpResponseHeaders": False,
+                    },
+                },
+            },
+            {},
+            {
+                "browserHtml": True,
+                "httpResponseHeaders": False,
+            },
+            [],
+        ),
+
+        # METHOD
+
+        # Request.method is mapped as is.
+        *(
+            (
+                {"method": method},
+                {},
+                {
+                    "httpResponseBody": True,
+                    "httpResponseHeaders": True,
+                    "httpRequestMethod": method,
+                },
+                [],
+            )
+            for method in (
+                "POST",
+                "PUT",
+                "DELETE",
+                "OPTIONS",
+                "TRACE",
+                "PATCH",
+            )
+        ),
+        # Request.method is mapped even for methods that Zyte Data API does not
+        # support.
+        *(
+            (
+                {"method": method},
+                {},
+                {
+                    "httpResponseBody": True,
+                    "httpResponseHeaders": True,
+                    "httpRequestMethod": method,
+                },
+                [],
+            )
+            for method in (
+                "HEAD",
+                "CONNECT",
+                "FOO",
+            )
+        ),
+        # An exception is the default method (GET), which is not mapped.
+        (
+            {"method": "GET"},
+            {},
+            {
+                "httpResponseBody": True,
+                "httpResponseHeaders": True,
+            },
+            [],
+        ),
+        # httpRequestMethod should not be defined through meta.
+        (
+            {
+                "meta": {
+                    "zyte_api": {
+                        "httpRequestMethod": "GET",
+                    },
+                },
+            },
+            {},
+            {
+                "httpResponseBody": True,
+                "httpResponseHeaders": True,
+                "httpRequestMethod": "GET",
+            },
+            ["Use Request.method instead"],
+        ),
+        # If defined through meta, httpRequestMethod takes precedence, warning
+        # about value mismatches.
+        (
+            {
+                "method": "POST",
+                "meta": {
+                    "zyte_api": {
+                        "httpRequestMethod": "PATCH",
+                    },
+                },
+            },
+            {},
+            {
+                "httpResponseBody": True,
+                "httpResponseHeaders": True,
+                "httpRequestMethod": "PATCH",
+            },
+            [
+                "Use Request.method instead",
+                "does not match the Zyte Data API httpRequestMethod parameter",
+            ],
+        ),
+        # A non-GET method should not be used unless httpResponseBody is also
+        # used.
+        (
+            {
+                "method": "POST",
+                "meta": {"zyte_api": {"browserHtml": True}},
+            },
+            {},
+            {
+                "browserHtml": True,
+                "httpResponseHeaders": True,
+            },
+            ["can only be set when the httpResponseBody parameter"],
+        ),
+        (
+            {
+                "method": "POST",
+                "meta": {"zyte_api": {"screenshot": True}},
+            },
+            {},
+            {
+                "screenshot": True,
+            },
+            ["can only be set when the httpResponseBody parameter"],
+        ),
+
+        # HEADERS
+
+        # Headers are mapped to requestHeaders or customHttpRequestHeaders
+        # depending on whether or not httpResponseBody is declared.
+        (
+            {
+                "headers": {"Referer": "a"},
+            },
+            {},
+            {
+                "httpResponseBody": True,
+                "httpResponseHeaders": True,
+                "customHttpRequestHeaders": [
+                    {"name": "Referer", "value": "a"},
+                ],
+            },
+            [],
+        ),
+        (
+            {
+                "headers": {"Referer": "a"},
+                "meta": {"zyte_api": {"browserHtml": True}},
+            },
+            {},
+            {
+                "browserHtml": True,
+                "httpResponseHeaders": True,
+                "requestHeaders": {"referer": "a"},
+            },
+            [],
+        ),
+        # We intentionally generate requestHeaders even if browserHtml and
+        # screenshot are not used, assuming that future additional outputs are
+        # more likely to use requestHeaders than to use
+        # customHttpRequestHeaders.
+        (
+            {
+                "headers": {"Referer": "a"},
+                "meta": {"zyte_api": {"httpResponseBody": False}},
+            },
+            {},
+            {
+                "httpResponseBody": False,
+                "requestHeaders": {"referer": "a"},
+            },
+            [],
+        ),
+        # If both httpResponseBody and currently-incompatible attributes
+        # (browserHtml, screenshot) are declared, both fields are generated.
+        # This is in case a single request is allowed to combine both in the
+        # future.
+        (
+            {
+                "headers": {"Referer": "a"},
+                "meta": {
+                    "zyte_api": {
+                        "httpResponseBody": True,
+                        "browserHtml": True,
+                        # Makes the mock API server return 200 despite the
+                        # bad input.
+                        "passThrough": True,
+                    },
+                },
+            },
+            {},
+            {
+                "httpResponseBody": True,
+                "browserHtml": True,
+                "httpResponseHeaders": True,
+                "customHttpRequestHeaders": [
+                    {"name": "Referer", "value": "a"},
+                ],
+                "requestHeaders": {"referer": "a"},
+                "passThrough": True,
+            },
+            [],
+        ),
+        # If requestHeaders or customHttpRequestHeaders are used, their value
+        # prevails, but a warning is issued.
+        (
+            {
+                "headers": {"Referer": "a"},
+                "meta": {
+                    "zyte_api": {
+                        "customHttpRequestHeaders": [
+                            {"name": "Referer", "value": "b"},
+                        ],
+                    },
+                },
+            },
+            {},
+            {
+                "httpResponseBody": True,
+                "httpResponseHeaders": True,
+                "customHttpRequestHeaders": [
+                    {"name": "Referer", "value": "b"},
+                ],
+            },
+            ["Use Request.headers instead"],
+        ),
+        (
+            {
+                "headers": {"Referer": "a"},
+                "meta": {
+                    "zyte_api": {
+                        "browserHtml": True,
+                        "requestHeaders": {"referer": "b"},
+                    },
+                },
+            },
+            {},
+            {
+                "browserHtml": True,
+                "httpResponseHeaders": True,
+                "requestHeaders": {"referer": "b"},
+            },
+            ["Use Request.headers instead"],
+        ),
+        # A request should not have headers if requestHeaders or
+        # customHttpRequestHeaders are also used, even if they match.
+        (
+            {
+                "headers": {"Referer": "b"},
+                "meta": {
+                    "zyte_api": {
+                        "customHttpRequestHeaders": [
+                            {"name": "Referer", "value": "b"},
+                        ],
+                    },
+                },
+            },
+            {},
+            {
+                "httpResponseBody": True,
+                "httpResponseHeaders": True,
+                "customHttpRequestHeaders": [
+                    {"name": "Referer", "value": "b"},
+                ],
+            },
+            ["Use Request.headers instead"],
+        ),
+        (
+            {
+                "headers": {"Referer": "b"},
+                "meta": {
+                    "zyte_api": {
+                        "browserHtml": True,
+                        "requestHeaders": {"referer": "b"},
+                    },
+                },
+            },
+            {},
+            {
+                "browserHtml": True,
+                "httpResponseHeaders": True,
+                "requestHeaders": {"referer": "b"},
+            },
+            ["Use Request.headers instead"],
+        ),
+        # Unsupported headers not present in Scrapy requests by default are
+        # dropped with a warning.
+        # If all headers are unsupported, the header parameter is not even set.
+        (
+            {
+                "headers": {"a": "b"},
+                "meta": {"zyte_api": {"browserHtml": True}},
+            },
+            {},
+            {
+                "browserHtml": True,
+                "httpResponseHeaders": True,
+            },
+            ["cannot be mapped"],
+        ),
+        # Headers with None as value are silently ignored.
+        (
+            {
+                "headers": {"a": None},
+                "meta": {"zyte_api": {"browserHtml": True}},
+            },
+            {},
+            {
+                "browserHtml": True,
+                "httpResponseHeaders": True,
+            },
+            [],
+        ),
+        # Headers with an empty string as value are not silently ignored.
+        (
+            {
+                "headers": {"a": ""},
+                "meta": {"zyte_api": {"browserHtml": True}},
+            },
+            {},
+            {
+                "browserHtml": True,
+                "httpResponseHeaders": True,
+            },
+            ["cannot be mapped"],
+        ),
+        # Unsupported headers are looked up case-insensitively.
+        (
+            {
+                "headers": {"user-Agent": ""},
+            },
+            {},
+            {
+                "httpResponseBody": True,
+                "httpResponseHeaders": True,
+            },
+            ["cannot be mapped"],
+        ),
+        # The Accept and Accept-Language headers, when unsupported, are dropped
+        # silently if their value matches the default value of Scrapy for
+        # DEFAULT_REQUEST_HEADERS, or with a warning otherwise.
+        (
+            {
+                "headers": DEFAULT_REQUEST_HEADERS,
+                "meta": {"zyte_api": {"browserHtml": True}},
+            },
+            {},
+            {
+                "browserHtml": True,
+                "httpResponseHeaders": True,
+            },
+            [],
+        ),
+        (
+            {
+                "headers": {
+                    "Accept": "application/json",
+                    "Accept-Language": "uk",
+                },
+                "meta": {"zyte_api": {"browserHtml": True}},
+            },
+            {},
+            {
+                "browserHtml": True,
+                "httpResponseHeaders": True,
+            },
+            ["cannot be mapped"],
+        ),
+        # The Cookie header is dropped with a warning.
+        (
+            {
+                "headers": {"Cookie": "a=b",},
+            },
+            {},
+            {
+                "httpResponseBody": True,
+                "httpResponseHeaders": True,
+            },
+            ["cannot be mapped"],
+        ),
+        (
+            {
+                "headers": {"Cookie": "a=b",},
+                "meta": {"zyte_api": {"browserHtml": True}},
+            },
+            {},
+            {
+                "browserHtml": True,
+                "httpResponseHeaders": True,
+            },
+            ["cannot be mapped"],
+        ),
+        # The User-Agent header, which Scrapy sets by default, is dropped
+        # silently if it matches the default value of the USER_AGENT setting,
+        # or with a warning otherwise.
+        (
+            {
+                "headers": {"User-Agent": DEFAULT_USER_AGENT},
+            },
+            {},
+            {
+                "httpResponseBody": True,
+                "httpResponseHeaders": True,
+            },
+            [],
+        ),
+        (
+            {
+                "headers": {"User-Agent": ""},
+            },
+            {},
+            {
+                "httpResponseBody": True,
+                "httpResponseHeaders": True,
+            },
+            ["cannot be mapped"],
+        ),
+        (
+            {
+                "headers": {"User-Agent": DEFAULT_USER_AGENT},
+                "meta": {"zyte_api": {"browserHtml": True}},
+            },
+            {},
+            {
+                "browserHtml": True,
+                "httpResponseHeaders": True,
+            },
+            [],
+        ),
+        (
+            {
+                "headers": {"User-Agent": ""},
+                "meta": {"zyte_api": {"browserHtml": True}},
+            },
+            {},
+            {
+                "browserHtml": True,
+                "httpResponseHeaders": True,
+            },
+            ["cannot be mapped"],
+        ),
+        # You may update the ZYTE_API_UNSUPPORTED_HEADERS setting to remove
+        # headers that the customHttpRequestHeaders parameter starts supporting
+        # in the future.
+        (
+            {
+                "headers": {"User-Agent": ""},
+            },
+            {
+                "ZYTE_API_UNSUPPORTED_HEADERS": ["Cookie"],
+            },
+            {
+                "httpResponseBody": True,
+                "httpResponseHeaders": True,
+                "customHttpRequestHeaders": [
+                    {"name": "User-Agent", "value": ""},
+                ],
+            },
+            [],
+        ),
+        # You may update the ZYTE_API_BROWSER_HEADERS setting to extend support
+        # for new fields that the requestHeaders parameter may support in the
+        # future.
+        (
+            {
+                "headers": {"User-Agent": ""},
+                "meta": {"zyte_api": {"browserHtml": True}},
+            },
+            {
+                "ZYTE_API_BROWSER_HEADERS": {
+                    "Referer": "referer",
+                    "User-Agent": "userAgent",
+                },
+            },
+            {
+                "browserHtml": True,
+                "httpResponseHeaders": True,
+                "requestHeaders": {"userAgent": ""},
+            },
+            [],
+        ),
+
+        # BODY
+
+        # The body is copied into httpRequestBody, base64-encoded.
+        (
+            {
+                "body": "a",
+            },
+            {},
+            {
+                "httpResponseBody": True,
+                "httpResponseHeaders": True,
+                "httpRequestBody": "YQ==",
+            },
+            [],
+        ),
+        # httpRequestBody defined in meta takes precedence, but it causes a
+        # warning.
+        (
+            {
+                "body": "a",
+                "meta": {"zyte_api": {"httpRequestBody": "Yg=="}},
+            },
+            {},
+            {
+                "httpResponseBody": True,
+                "httpResponseHeaders": True,
+                "httpRequestBody": "Yg==",
+            },
+            [
+                "Use Request.body instead",
+                "does not match the Zyte Data API httpRequestBody parameter",
+            ],
+        ),
+        # httpRequestBody defined in meta causes a warning even if it matches
+        # request.body.
+        (
+            {
+                "body": "a",
+                "meta": {"zyte_api": {"httpRequestBody": "YQ=="}},
+            },
+            {},
+            {
+                "httpResponseBody": True,
+                "httpResponseHeaders": True,
+                "httpRequestBody": "YQ==",
+            },
+            ["Use Request.body instead"],
+        ),
+        # A body should not be used unless httpResponseBody is also used.
+        (
+            {
+                "body": "a",
+                "meta": {"zyte_api": {"browserHtml": True}},
+            },
+            {},
+            {
+                "browserHtml": True,
+                "httpResponseHeaders": True,
+            },
+            ["can only be set when the httpResponseBody parameter"],
+        ),
+        (
+            {
+                "body": "a",
+                "meta": {"zyte_api": {"screenshot": True}},
+            },
+            {},
+            {
+                "screenshot": True,
+            },
+            ["can only be set when the httpResponseBody parameter"],
+        ),
+
+        # httpResponseHeaders
+
+        # Warn if httpResponseHeaders is defined unnecessarily.
+        (
+            {
+                "meta": {"zyte_api": {"httpResponseHeaders": True}},
+            },
+            {},
+            {
+                "httpResponseBody": True,
+                "httpResponseHeaders": True,
+            },
+            ["do not need to set httpResponseHeaders"],
+        ),
+    ],
+)
+async def test_automap(
+    request_kwargs: Dict[str, Any],
+    settings: Dict[str, str],
+    expected: Union[Dict[str, str], Literal[False]],
+    warnings: List[str],
+    mockserver,
+    caplog,
+):
+    settings.update({"ZYTE_API_ON_ALL_REQUESTS": True})
+    async with mockserver.make_handler(settings) as handler:
+        if expected is False:
+            # Only the Zyte Data API client is mocked, meaning requests that
+            # do not go through Zyte Data API are actually sent, so we point
+            # them to the mock server to avoid internet connections in tests.
+            request_kwargs["url"] = mockserver.urljoin("/")
+        else:
+            request_kwargs["url"] = "https://toscrape.com"
+        request = Request(**request_kwargs)
+        unmocked_client = handler._client
+        handler._client = mock.AsyncMock(unmocked_client)
+        handler._client.request_raw.side_effect = unmocked_client.request_raw
+        with caplog.at_level("WARNING"):
+            await handler.download_request(request, None)
+
+        # What we're interested in is the Request call in the API
+        request_call = [
+            c for c in handler._client.mock_calls if "request_raw(" in str(c)
+        ]
+
+        if expected is False:
+            assert request_call == []
+            return
+
+        if not request_call:
+            pytest.fail("The client's request_raw() method was not called.")
+
+        args_used = request_call[0].args[0]
+        args_used.pop("url")
+        assert args_used == expected
+
+        if warnings:
+            for warning in warnings:
+                assert warning in caplog.text
+        else:
+            assert not caplog.records

--- a/tests/test_api_requests.py
+++ b/tests/test_api_requests.py
@@ -95,7 +95,7 @@ async def test_http_response_headers_request(meta: Dict[str, Dict[str, Any]], mo
 @pytest.mark.parametrize(
     "meta,settings,expected,use_zyte_api",
     [
-        # Default ZYTE_API_ALL
+        # Default ZYTE_API_ON_ALL_REQUESTS
         ({}, {}, {}, False),
         ({"zyte_api": {}}, {}, {}, False),
         ({"zyte_api": True}, {}, {}, False),
@@ -137,16 +137,16 @@ async def test_http_response_headers_request(meta: Dict[str, Dict[str, Any]], mo
             True,
         ),
 
-        # ZYTE_API_ALL=False
-        ({}, {"ZYTE_API_ALL": False}, {}, False),
-        ({"zyte_api": {}}, {"ZYTE_API_ALL": False}, {}, False),
-        ({"zyte_api": True}, {"ZYTE_API_ALL": False}, {}, False),
-        ({"zyte_api": False}, {"ZYTE_API_ALL": False}, {}, False),
+        # ZYTE_API_ON_ALL_REQUESTS=False
+        ({}, {"ZYTE_API_ON_ALL_REQUESTS": False}, {}, False),
+        ({"zyte_api": {}}, {"ZYTE_API_ON_ALL_REQUESTS": False}, {}, False),
+        ({"zyte_api": True}, {"ZYTE_API_ON_ALL_REQUESTS": False}, {}, False),
+        ({"zyte_api": False}, {"ZYTE_API_ON_ALL_REQUESTS": False}, {}, False),
         (
             {},
             {
                 "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
-                "ZYTE_API_ALL": False,
+                "ZYTE_API_ON_ALL_REQUESTS": False,
             },
             {"browserHtml": True, "geolocation": "CA"},
             False,
@@ -155,7 +155,7 @@ async def test_http_response_headers_request(meta: Dict[str, Dict[str, Any]], mo
             {"zyte_api": False},
             {
                 "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
-                "ZYTE_API_ALL": False,
+                "ZYTE_API_ON_ALL_REQUESTS": False,
             },
             {},
             False,
@@ -164,7 +164,7 @@ async def test_http_response_headers_request(meta: Dict[str, Dict[str, Any]], mo
             {"zyte_api": None},
             {
                 "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
-                "ZYTE_API_ALL": False,
+                "ZYTE_API_ON_ALL_REQUESTS": False,
             },
             {},
             False,
@@ -173,7 +173,7 @@ async def test_http_response_headers_request(meta: Dict[str, Dict[str, Any]], mo
             {"zyte_api": {}},
             {
                 "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
-                "ZYTE_API_ALL": False,
+                "ZYTE_API_ON_ALL_REQUESTS": False,
             },
             {"browserHtml": True, "geolocation": "CA"},
             True,
@@ -182,7 +182,7 @@ async def test_http_response_headers_request(meta: Dict[str, Dict[str, Any]], mo
             {"zyte_api": True},
             {
                 "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
-                "ZYTE_API_ALL": False,
+                "ZYTE_API_ON_ALL_REQUESTS": False,
             },
             {"browserHtml": True, "geolocation": "CA"},
             True,
@@ -191,22 +191,22 @@ async def test_http_response_headers_request(meta: Dict[str, Dict[str, Any]], mo
             {"zyte_api": {"javascript": True, "geolocation": "US"}},
             {
                 "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
-                "ZYTE_API_ALL": False,
+                "ZYTE_API_ON_ALL_REQUESTS": False,
             },
             {"browserHtml": True, "geolocation": "US", "javascript": True},
             True,
         ),
 
-        # ZYTE_API_ALL=True
-        ({}, {"ZYTE_API_ALL": True}, {}, False),
-        ({"zyte_api": {}}, {"ZYTE_API_ALL": True}, {}, False),
-        ({"zyte_api": True}, {"ZYTE_API_ALL": True}, {}, False),
-        ({"zyte_api": False}, {"ZYTE_API_ALL": True}, {}, False),
+        # ZYTE_API_ON_ALL_REQUESTS=True
+        ({}, {"ZYTE_API_ON_ALL_REQUESTS": True}, {}, False),
+        ({"zyte_api": {}}, {"ZYTE_API_ON_ALL_REQUESTS": True}, {}, False),
+        ({"zyte_api": True}, {"ZYTE_API_ON_ALL_REQUESTS": True}, {}, False),
+        ({"zyte_api": False}, {"ZYTE_API_ON_ALL_REQUESTS": True}, {}, False),
         (
             {},
             {
                 "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
-                "ZYTE_API_ALL": True,
+                "ZYTE_API_ON_ALL_REQUESTS": True,
             },
             {"browserHtml": True, "geolocation": "CA"},
             True,
@@ -215,7 +215,7 @@ async def test_http_response_headers_request(meta: Dict[str, Dict[str, Any]], mo
             {"zyte_api": False},
             {
                 "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
-                "ZYTE_API_ALL": True,
+                "ZYTE_API_ON_ALL_REQUESTS": True,
             },
             {},
             False,
@@ -224,7 +224,7 @@ async def test_http_response_headers_request(meta: Dict[str, Dict[str, Any]], mo
             {"zyte_api": None},
             {
                 "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
-                "ZYTE_API_ALL": True,
+                "ZYTE_API_ON_ALL_REQUESTS": True,
             },
             {},
             False,
@@ -233,7 +233,7 @@ async def test_http_response_headers_request(meta: Dict[str, Dict[str, Any]], mo
             {"zyte_api": {}},
             {
                 "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
-                "ZYTE_API_ALL": True,
+                "ZYTE_API_ON_ALL_REQUESTS": True,
             },
             {"browserHtml": True, "geolocation": "CA"},
             True,
@@ -242,7 +242,7 @@ async def test_http_response_headers_request(meta: Dict[str, Dict[str, Any]], mo
             {"zyte_api": True},
             {
                 "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
-                "ZYTE_API_ALL": True,
+                "ZYTE_API_ON_ALL_REQUESTS": True,
             },
             {"browserHtml": True, "geolocation": "CA"},
             True,
@@ -251,7 +251,7 @@ async def test_http_response_headers_request(meta: Dict[str, Dict[str, Any]], mo
             {"zyte_api": {"javascript": True, "geolocation": "US"}},
             {
                 "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
-                "ZYTE_API_ALL": True,
+                "ZYTE_API_ON_ALL_REQUESTS": True,
             },
             {"browserHtml": True, "geolocation": "US", "javascript": True},
             True,

--- a/tests/test_api_requests.py
+++ b/tests/test_api_requests.py
@@ -95,7 +95,7 @@ async def test_http_response_headers_request(meta: Dict[str, Dict[str, Any]], mo
 @pytest.mark.parametrize(
     "meta,settings,expected,use_zyte_api",
     [
-        # Undefined ZYTE_API_ENABLED
+        # Default ZYTE_API_ALL
         ({}, {}, {}, False),
         ({"zyte_api": {}}, {}, {}, False),
         ({"zyte_api": True}, {}, {}, False),
@@ -137,16 +137,16 @@ async def test_http_response_headers_request(meta: Dict[str, Dict[str, Any]], mo
             True,
         ),
 
-        # ZYTE_API_ENABLED=None
-        ({}, {"ZYTE_API_ENABLED": None}, {}, False),
-        ({"zyte_api": {}}, {"ZYTE_API_ENABLED": None}, {}, False),
-        ({"zyte_api": True}, {"ZYTE_API_ENABLED": None}, {}, False),
-        ({"zyte_api": False}, {"ZYTE_API_ENABLED": None}, {}, False),
+        # ZYTE_API_ALL=False
+        ({}, {"ZYTE_API_ALL": False}, {}, False),
+        ({"zyte_api": {}}, {"ZYTE_API_ALL": False}, {}, False),
+        ({"zyte_api": True}, {"ZYTE_API_ALL": False}, {}, False),
+        ({"zyte_api": False}, {"ZYTE_API_ALL": False}, {}, False),
         (
             {},
             {
                 "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
-                "ZYTE_API_ENABLED": None,
+                "ZYTE_API_ALL": False,
             },
             {"browserHtml": True, "geolocation": "CA"},
             False,
@@ -155,7 +155,7 @@ async def test_http_response_headers_request(meta: Dict[str, Dict[str, Any]], mo
             {"zyte_api": False},
             {
                 "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
-                "ZYTE_API_ENABLED": None,
+                "ZYTE_API_ALL": False,
             },
             {},
             False,
@@ -164,7 +164,7 @@ async def test_http_response_headers_request(meta: Dict[str, Dict[str, Any]], mo
             {"zyte_api": None},
             {
                 "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
-                "ZYTE_API_ENABLED": None,
+                "ZYTE_API_ALL": False,
             },
             {},
             False,
@@ -173,7 +173,7 @@ async def test_http_response_headers_request(meta: Dict[str, Dict[str, Any]], mo
             {"zyte_api": {}},
             {
                 "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
-                "ZYTE_API_ENABLED": None,
+                "ZYTE_API_ALL": False,
             },
             {"browserHtml": True, "geolocation": "CA"},
             True,
@@ -182,7 +182,7 @@ async def test_http_response_headers_request(meta: Dict[str, Dict[str, Any]], mo
             {"zyte_api": True},
             {
                 "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
-                "ZYTE_API_ENABLED": None,
+                "ZYTE_API_ALL": False,
             },
             {"browserHtml": True, "geolocation": "CA"},
             True,
@@ -191,22 +191,22 @@ async def test_http_response_headers_request(meta: Dict[str, Dict[str, Any]], mo
             {"zyte_api": {"javascript": True, "geolocation": "US"}},
             {
                 "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
-                "ZYTE_API_ENABLED": None,
+                "ZYTE_API_ALL": False,
             },
             {"browserHtml": True, "geolocation": "US", "javascript": True},
             True,
         ),
 
-        # ZYTE_API_ENABLED=True
-        ({}, {"ZYTE_API_ENABLED": True}, {}, False),
-        ({"zyte_api": {}}, {"ZYTE_API_ENABLED": True}, {}, False),
-        ({"zyte_api": True}, {"ZYTE_API_ENABLED": True}, {}, False),
-        ({"zyte_api": False}, {"ZYTE_API_ENABLED": True}, {}, False),
+        # ZYTE_API_ALL=True
+        ({}, {"ZYTE_API_ALL": True}, {}, False),
+        ({"zyte_api": {}}, {"ZYTE_API_ALL": True}, {}, False),
+        ({"zyte_api": True}, {"ZYTE_API_ALL": True}, {}, False),
+        ({"zyte_api": False}, {"ZYTE_API_ALL": True}, {}, False),
         (
             {},
             {
                 "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
-                "ZYTE_API_ENABLED": True,
+                "ZYTE_API_ALL": True,
             },
             {"browserHtml": True, "geolocation": "CA"},
             True,
@@ -215,7 +215,7 @@ async def test_http_response_headers_request(meta: Dict[str, Dict[str, Any]], mo
             {"zyte_api": False},
             {
                 "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
-                "ZYTE_API_ENABLED": True,
+                "ZYTE_API_ALL": True,
             },
             {},
             False,
@@ -224,7 +224,7 @@ async def test_http_response_headers_request(meta: Dict[str, Dict[str, Any]], mo
             {"zyte_api": None},
             {
                 "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
-                "ZYTE_API_ENABLED": True,
+                "ZYTE_API_ALL": True,
             },
             {},
             False,
@@ -233,7 +233,7 @@ async def test_http_response_headers_request(meta: Dict[str, Dict[str, Any]], mo
             {"zyte_api": {}},
             {
                 "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
-                "ZYTE_API_ENABLED": True,
+                "ZYTE_API_ALL": True,
             },
             {"browserHtml": True, "geolocation": "CA"},
             True,
@@ -242,7 +242,7 @@ async def test_http_response_headers_request(meta: Dict[str, Dict[str, Any]], mo
             {"zyte_api": True},
             {
                 "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
-                "ZYTE_API_ENABLED": True,
+                "ZYTE_API_ALL": True,
             },
             {"browserHtml": True, "geolocation": "CA"},
             True,
@@ -251,70 +251,10 @@ async def test_http_response_headers_request(meta: Dict[str, Dict[str, Any]], mo
             {"zyte_api": {"javascript": True, "geolocation": "US"}},
             {
                 "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
-                "ZYTE_API_ENABLED": True,
+                "ZYTE_API_ALL": True,
             },
             {"browserHtml": True, "geolocation": "US", "javascript": True},
             True,
-        ),
-
-        # ZYTE_API_ENABLED=False
-        ({}, {"ZYTE_API_ENABLED": True}, {}, False),
-        ({"zyte_api": {}}, {"ZYTE_API_ENABLED": False}, {}, False),
-        ({"zyte_api": True}, {"ZYTE_API_ENABLED": False}, {}, False),
-        ({"zyte_api": False}, {"ZYTE_API_ENABLED": False}, {}, False),
-        (
-            {},
-            {
-                "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
-                "ZYTE_API_ENABLED": False,
-            },
-            {"browserHtml": True, "geolocation": "CA"},
-            False,
-        ),
-        (
-            {"zyte_api": False},
-            {
-                "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
-                "ZYTE_API_ENABLED": False,
-            },
-            {},
-            False,
-        ),
-        (
-            {"zyte_api": None},
-            {
-                "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
-                "ZYTE_API_ENABLED": False,
-            },
-            {},
-            False,
-        ),
-        (
-            {"zyte_api": {}},
-            {
-                "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
-                "ZYTE_API_ENABLED": False,
-            },
-            {"browserHtml": True, "geolocation": "CA"},
-            False,
-        ),
-        (
-            {"zyte_api": True},
-            {
-                "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
-                "ZYTE_API_ENABLED": False,
-            },
-            {"browserHtml": True, "geolocation": "CA"},
-            False,
-        ),
-        (
-            {"zyte_api": {"javascript": True, "geolocation": "US"}},
-            {
-                "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
-                "ZYTE_API_ENABLED": False,
-            },
-            {"browserHtml": True, "geolocation": "US", "javascript": True},
-            False,
         ),
     ],
 )
@@ -326,9 +266,6 @@ async def test_zyte_api_request_meta(
     mockserver,
 ):
     async with mockserver.make_handler(settings) as handler:
-        if handler is None:
-            assert not use_zyte_api
-            return
         req = Request(mockserver.urljoin("/"), meta=meta)
         unmocked_client = handler._client
         handler._client = mock.AsyncMock(unmocked_client)
@@ -352,6 +289,13 @@ async def test_zyte_api_request_meta(
         args_used.pop("url")
 
         assert args_used == expected
+
+
+@ensureDeferred
+async def test_disable(mockserver):
+    settings = {"ZYTE_API_ENABLED": False}
+    async with mockserver.make_handler(settings) as handler:
+        assert handler is None
 
 
 @ensureDeferred

--- a/tests/test_api_requests.py
+++ b/tests/test_api_requests.py
@@ -91,9 +91,11 @@ async def test_http_response_headers_request(meta: Dict[str, Dict[str, Any]], mo
 
 @ensureDeferred
 @pytest.mark.skipif(sys.version_info < (3, 8), reason="unittest.mock.AsyncMock")
+@pytest.mark.filterwarnings("ignore:.*None is deprecated")
 @pytest.mark.parametrize(
     "meta,settings,expected,use_zyte_api",
     [
+        # Undefined ZYTE_API_ENABLED
         ({}, {}, {}, False),
         ({"zyte_api": {}}, {}, {}, False),
         ({"zyte_api": True}, {}, {}, False),
@@ -134,6 +136,186 @@ async def test_http_response_headers_request(meta: Dict[str, Dict[str, Any]], mo
             {"browserHtml": True, "geolocation": "US", "javascript": True},
             True,
         ),
+
+        # ZYTE_API_ENABLED=None
+        ({}, {"ZYTE_API_ENABLED": None}, {}, False),
+        ({"zyte_api": {}}, {"ZYTE_API_ENABLED": None}, {}, False),
+        ({"zyte_api": True}, {"ZYTE_API_ENABLED": None}, {}, False),
+        ({"zyte_api": False}, {"ZYTE_API_ENABLED": None}, {}, False),
+        (
+            {},
+            {
+                "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
+                "ZYTE_API_ENABLED": None,
+            },
+            {"browserHtml": True, "geolocation": "CA"},
+            False,
+        ),
+        (
+            {"zyte_api": False},
+            {
+                "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
+                "ZYTE_API_ENABLED": None,
+            },
+            {},
+            False,
+        ),
+        (
+            {"zyte_api": None},
+            {
+                "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
+                "ZYTE_API_ENABLED": None,
+            },
+            {},
+            False,
+        ),
+        (
+            {"zyte_api": {}},
+            {
+                "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
+                "ZYTE_API_ENABLED": None,
+            },
+            {"browserHtml": True, "geolocation": "CA"},
+            True,
+        ),
+        (
+            {"zyte_api": True},
+            {
+                "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
+                "ZYTE_API_ENABLED": None,
+            },
+            {"browserHtml": True, "geolocation": "CA"},
+            True,
+        ),
+        (
+            {"zyte_api": {"javascript": True, "geolocation": "US"}},
+            {
+                "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
+                "ZYTE_API_ENABLED": None,
+            },
+            {"browserHtml": True, "geolocation": "US", "javascript": True},
+            True,
+        ),
+
+        # ZYTE_API_ENABLED=True
+        ({}, {"ZYTE_API_ENABLED": True}, {}, False),
+        ({"zyte_api": {}}, {"ZYTE_API_ENABLED": True}, {}, False),
+        ({"zyte_api": True}, {"ZYTE_API_ENABLED": True}, {}, False),
+        ({"zyte_api": False}, {"ZYTE_API_ENABLED": True}, {}, False),
+        (
+            {},
+            {
+                "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
+                "ZYTE_API_ENABLED": True,
+            },
+            {"browserHtml": True, "geolocation": "CA"},
+            True,
+        ),
+        (
+            {"zyte_api": False},
+            {
+                "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
+                "ZYTE_API_ENABLED": True,
+            },
+            {},
+            False,
+        ),
+        (
+            {"zyte_api": None},
+            {
+                "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
+                "ZYTE_API_ENABLED": True,
+            },
+            {},
+            False,
+        ),
+        (
+            {"zyte_api": {}},
+            {
+                "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
+                "ZYTE_API_ENABLED": True,
+            },
+            {"browserHtml": True, "geolocation": "CA"},
+            True,
+        ),
+        (
+            {"zyte_api": True},
+            {
+                "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
+                "ZYTE_API_ENABLED": True,
+            },
+            {"browserHtml": True, "geolocation": "CA"},
+            True,
+        ),
+        (
+            {"zyte_api": {"javascript": True, "geolocation": "US"}},
+            {
+                "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
+                "ZYTE_API_ENABLED": True,
+            },
+            {"browserHtml": True, "geolocation": "US", "javascript": True},
+            True,
+        ),
+
+        # ZYTE_API_ENABLED=False
+        ({}, {"ZYTE_API_ENABLED": True}, {}, False),
+        ({"zyte_api": {}}, {"ZYTE_API_ENABLED": False}, {}, False),
+        ({"zyte_api": True}, {"ZYTE_API_ENABLED": False}, {}, False),
+        ({"zyte_api": False}, {"ZYTE_API_ENABLED": False}, {}, False),
+        (
+            {},
+            {
+                "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
+                "ZYTE_API_ENABLED": False,
+            },
+            {"browserHtml": True, "geolocation": "CA"},
+            False,
+        ),
+        (
+            {"zyte_api": False},
+            {
+                "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
+                "ZYTE_API_ENABLED": False,
+            },
+            {},
+            False,
+        ),
+        (
+            {"zyte_api": None},
+            {
+                "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
+                "ZYTE_API_ENABLED": False,
+            },
+            {},
+            False,
+        ),
+        (
+            {"zyte_api": {}},
+            {
+                "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
+                "ZYTE_API_ENABLED": False,
+            },
+            {"browserHtml": True, "geolocation": "CA"},
+            False,
+        ),
+        (
+            {"zyte_api": True},
+            {
+                "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
+                "ZYTE_API_ENABLED": False,
+            },
+            {"browserHtml": True, "geolocation": "CA"},
+            False,
+        ),
+        (
+            {"zyte_api": {"javascript": True, "geolocation": "US"}},
+            {
+                "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True, "geolocation": "CA"},
+                "ZYTE_API_ENABLED": False,
+            },
+            {"browserHtml": True, "geolocation": "US", "javascript": True},
+            False,
+        ),
     ],
 )
 async def test_zyte_api_request_meta(
@@ -144,10 +326,14 @@ async def test_zyte_api_request_meta(
     mockserver,
 ):
     async with mockserver.make_handler(settings) as handler:
+        if handler is None:
+            assert not use_zyte_api
+            return
         req = Request(mockserver.urljoin("/"), meta=meta)
         unmocked_client = handler._client
         handler._client = mock.AsyncMock(unmocked_client)
         handler._client.request_raw.side_effect = unmocked_client.request_raw
+
         await handler.download_request(req, None)
 
         # What we're interested in is the Request call in the API
@@ -168,6 +354,16 @@ async def test_zyte_api_request_meta(
         assert args_used == expected
 
 
+@ensureDeferred
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="unittest.mock.AsyncMock")
+async def test_zyte_api_request_meta_none_deprecation(mockserver):
+    async with mockserver.make_handler() as handler:
+        req = Request(mockserver.urljoin("/"), meta={"zyte_api": None})
+        handler._client = mock.AsyncMock(handler._client)
+        with pytest.warns(DeprecationWarning, match="None is deprecated"):
+            await handler.download_request(req, None)
+
+
 @pytest.mark.parametrize(
     "meta",
     [
@@ -175,7 +371,7 @@ async def test_zyte_api_request_meta(
         {"zyte_api": True},
         {"zyte_api": {"browserHtml": True}},
         {"zyte_api": {}},
-        {"zyte_api": None},
+        {"zyte_api": False},
         {"randomParameter": True},
         {},
         None,


### PR DESCRIPTION
Built on top of https://github.com/scrapy-plugins/scrapy-zyte-api/pull/40, this pull request aims to address point 4 from https://github.com/scrapy-plugins/scrapy-zyte-api/pull/40#discussion_r944261278.

Please, ignore the actual implementation at the time being, and instead have a look at the test scenarios introduced here. I think we should discuss changes, additions and removals around those before moving forward. Questions to discuss include:
- Are we OK with making the feature opt-out, or should it be opt-in?
- Better suggestions for new settings? Are the two future-proofing-related settings worth adding?
- Any additional considerations to make the plugin more future-proof? Does any of the approaches go too far?
- Are we OK with the approach to warning, and the scenarios causing a warning? Should we be more lenient with headers about warnings? Is it OK to warn against request metadata usage for all keys that can be defined through request attributes?

To do:
- [ ] Agree on specifications based on test scenarios.
- [ ] Refactor the implementation.
- [ ] Provide documentation.

Resolves https://github.com/scrapy-plugins/scrapy-zyte-api/issues/16, resolves https://github.com/scrapy-plugins/scrapy-zyte-api/issues/17, resolves https://github.com/scrapy-plugins/scrapy-zyte-api/issues/19.