### PR TITLE
use zyte_api.aio.errors.RequestError instead of IgnoreRequest

### DIFF
--- a/scrapy_zyte_api/handler.py
+++ b/scrapy_zyte_api/handler.py
@@ -76,11 +76,11 @@ class ScrapyZyteAPIDownloadHandler(HTTPDownloadHandler):
         api_params: Dict[str, Any] = self._zyte_api_default_params or {}
         try:
             api_params.update(meta_params)
-        except TypeError:
+        except ValueError:
             logger.error(
-                f"zyte_api parameters in the request meta should be "
+                f"'zyte_api' parameters in the request meta should be "
                 f"provided as dictionary, got {type(request.meta.get('zyte_api'))} "
-                f"instead ({request.url})."
+                f"instead. ({request})."
             )
             raise
         return api_params

--- a/scrapy_zyte_api/handler.py
+++ b/scrapy_zyte_api/handler.py
@@ -76,7 +76,7 @@ class ScrapyZyteAPIDownloadHandler(HTTPDownloadHandler):
         api_params: Dict[str, Any] = self._zyte_api_default_params or {}
         try:
             api_params.update(meta_params)
-        except ValueError:
+        except (ValueError, TypeError):
             logger.error(
                 f"'zyte_api' parameters in the request meta should be "
                 f"provided as dictionary, got {type(request.meta.get('zyte_api'))} "

--- a/scrapy_zyte_api/handler.py
+++ b/scrapy_zyte_api/handler.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Generator, Optional, Union
 from scrapy import Spider
 from scrapy.core.downloader.handlers.http import HTTPDownloadHandler
 from scrapy.crawler import Crawler
-from scrapy.exceptions import IgnoreRequest, NotConfigured
+from scrapy.exceptions import NotConfigured
 from scrapy.http import Request
 from scrapy.settings import Settings
 from scrapy.utils.defer import deferred_from_coro
@@ -82,7 +82,7 @@ class ScrapyZyteAPIDownloadHandler(HTTPDownloadHandler):
                 f"provided as dictionary, got {type(request.meta.get('zyte_api'))} "
                 f"instead ({request.url})."
             )
-            raise IgnoreRequest()
+            raise
         return api_params
 
     def _update_stats(self):
@@ -152,7 +152,7 @@ class ScrapyZyteAPIDownloadHandler(HTTPDownloadHandler):
             logger.error(
                 f"Got an error when processing Zyte API request ({request.url}): {er}"
             )
-            raise IgnoreRequest()
+            raise
         finally:
             self._update_stats()
 

--- a/scrapy_zyte_api/handler.py
+++ b/scrapy_zyte_api/handler.py
@@ -147,7 +147,7 @@ class ScrapyZyteAPIDownloadHandler(HTTPDownloadHandler):
                 f"Got Zyte API error (status={er.status}, type={er.parsed.type!r}) "
                 f"while processing URL ({request.url}): {error_detail}"
             )
-            raise IgnoreRequest()
+            raise er
         except Exception as er:
             logger.error(
                 f"Got an error when processing Zyte API request ({request.url}): {er}"

--- a/scrapy_zyte_api/handler.py
+++ b/scrapy_zyte_api/handler.py
@@ -147,7 +147,7 @@ class ScrapyZyteAPIDownloadHandler(HTTPDownloadHandler):
                 f"Got Zyte API error (status={er.status}, type={er.parsed.type!r}) "
                 f"while processing URL ({request.url}): {error_detail}"
             )
-            raise er
+            raise
         except Exception as er:
             logger.error(
                 f"Got an error when processing Zyte API request ({request.url}): {er}"

--- a/tests/test_api_requests.py
+++ b/tests/test_api_requests.py
@@ -7,7 +7,7 @@ import pytest
 from _pytest.logging import LogCaptureFixture  # NOQA
 from pytest_twisted import ensureDeferred
 from scrapy import Request, Spider
-from scrapy.exceptions import IgnoreRequest, NotSupported
+from scrapy.exceptions import NotSupported
 from scrapy.http import Response, TextResponse
 from scrapy.utils.defer import deferred_from_coro
 from scrapy.utils.test import get_crawler
@@ -204,7 +204,7 @@ async def test_coro_handling(meta: Dict[str, Dict[str, Any]], mockserver):
     [
         (
             {"zyte_api": {"echoData": Request("http://test.com")}},
-            IgnoreRequest,
+            TypeError,
             "Got an error when processing Zyte API request (http://example.com): "
             "Object of type Request is not JSON serializable",
         ),

--- a/tests/test_api_requests.py
+++ b/tests/test_api_requests.py
@@ -209,6 +209,12 @@ async def test_coro_handling(meta: Dict[str, Dict[str, Any]], mockserver):
             "Object of type Request is not JSON serializable",
         ),
         (
+            {"zyte_api": ["some", "bad", "non-dict", "value"]},
+            ValueError,
+            "'zyte_api' parameters in the request meta should be provided as "
+            "dictionary, got <class 'list'> instead. (<POST http://example.com>).",
+        ),
+        (
             {"zyte_api": {"browserHtml": True, "httpResponseBody": True}},
             RequestError,
             "Got Zyte API error (status=422, type='/request/unprocessable') while processing URL (http://example.com): "
@@ -225,9 +231,9 @@ async def test_exceptions(
 ):
     async with mockserver.make_handler() as handler:
         req = Request("http://example.com", method="POST", meta=meta)
-        api_params = handler._prepare_api_params(req)
 
         with pytest.raises(exception_type):  # NOQA
+            api_params = handler._prepare_api_params(req)
             await deferred_from_coro(
                 handler._download_request(api_params, req, Spider("test"))  # NOQA
             )  # NOQA

--- a/tests/test_api_requests.py
+++ b/tests/test_api_requests.py
@@ -215,6 +215,12 @@ async def test_coro_handling(meta: Dict[str, Dict[str, Any]], mockserver):
             "dictionary, got <class 'list'> instead. (<POST http://example.com>).",
         ),
         (
+            {"zyte_api": 1},
+            TypeError,
+            "'zyte_api' parameters in the request meta should be provided as "
+            "dictionary, got <class 'int'> instead. (<POST http://example.com>).",
+        ),
+        (
             {"zyte_api": {"browserHtml": True, "httpResponseBody": True}},
             RequestError,
             "Got Zyte API error (status=422, type='/request/unprocessable') while processing URL (http://example.com): "

--- a/tests/test_api_requests.py
+++ b/tests/test_api_requests.py
@@ -12,6 +12,7 @@ from scrapy.http import Response, TextResponse
 from scrapy.utils.defer import deferred_from_coro
 from scrapy.utils.test import get_crawler
 from twisted.internet.defer import Deferred
+from zyte_api.aio.errors import RequestError
 
 from . import DEFAULT_CLIENT_CONCURRENCY, SETTINGS
 from .mockserver import DelayedResource, MockServer, produce_request_response
@@ -209,7 +210,7 @@ async def test_coro_handling(meta: Dict[str, Dict[str, Any]], mockserver):
         ),
         (
             {"zyte_api": {"browserHtml": True, "httpResponseBody": True}},
-            IgnoreRequest,
+            RequestError,
             "Got Zyte API error (status=422, type='/request/unprocessable') while processing URL (http://example.com): "
             "Incompatible parameters were found in the request.",
         ),


### PR DESCRIPTION
Resolves https://github.com/scrapy-plugins/scrapy-zyte-api/issues/25

---

+1 on using the original `zyte_api.aio.errors.RequestError` instead of `scrapy.exceptions.IgnoreRequest` as it provides a lot more information regarding the error.

This means developers could have accompanying debugging information should they need:

```
print(type(error))
# <class 'zyte_api.aio.errors.RequestError'>

print(error.response_content)
# b'{"type":"/request/invalid","title":"Bad Request","status":400,"detail":"malformed URL"}'

print(error.request_info)
# RequestInfo(url=URL('https://api.zyte.com/v1/extract'), method='POST', headers=<CIMultiDictProxy('Host': 'api.zyte.com', 'User-Agent': 'python-zyte-api/0.1.3 aiohttp/3.8.1', 'Accept': '*/*', 'Accept-Encoding': 'gzip, deflate', 'Authorization': 'Basic YWNkMDBjgTVhNjk5NDdhM2JsNWViM2QyYmY0ODg4OTM7', 'Content-Length': '35', 'Content-Type': 'application/json')>, real_url=URL('https://api.zyte.com/v1/extract'))

print(error.status)
# 400

print(error.headers)
# <CIMultiDictProxy('Date': 'Tue, 16 Aug 2022 06:29:26 GMT', 'Content-Type': 'application/problem+json', 'Content-Length': '98', 'Connection': 'keep-alive', 'Vary': 'Accept-Encoding', 'Content-Encoding': 'gzip', 'Strict-Transport-Security': 'max-age=0; includeSubDomains; preload')>

print(error.message)
# 'Bad Request'

print(error.parsed)
# ParsedError(response_body=b'{"type":"/request/invalid","title":"Bad Request","status":400,"detail":"malformed URL"}', data={'type': '/request/invalid', 'title': 'Bad Request', 'status': 400, 'detail': 'malformed URL'}, parse_error=None)
```