### PR TITLE
Prepare for 0.5.1 release

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.0
+current_version = 0.5.1
 commit = True
 tag = True
 tag_name = {new_version}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changes
 =======
 
+0.5.1 (2022-09-20)
+------------------
+
+* Raise the minimum dependency of Zyte API's Python API to ``zyte-api>=0.4.0``.
+  This changes all the requests to Zyte API to have have ``Accept-Encoding: br``
+  and automatically decompress brotli responses.
+
 0.5.0 (2022-08-25)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Changes
 * Raise the minimum dependency of Zyte API's Python API to ``zyte-api>=0.4.0``.
   This changes all the requests to Zyte API to have have ``Accept-Encoding: br``
   and automatically decompress brotli responses.
+* Rename "Zyte Data API" to simply "Zyte API" in the README.
+* Lower the minimum Scrapy version from ``2.6.0`` to ``2.0.1``.
 
 0.5.0 (2022-08-25)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="scrapy-zyte-api",
-    version="0.5.0",
+    version="0.5.1",
     description="Client library to process URLs through Zyte API",
     long_description=open("README.rst").read(),
     long_description_content_type="text/x-rst",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     install_requires=[
         "packaging>=14.0",
         "scrapy>=2.0.1",
-        "zyte-api>=0.3.0",
+        "zyte-api>=0.4.0",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ commands =
 deps =
     {[testenv]deps}
     packaging==14.0
-    zyte-api==0.3.0
+    zyte-api==0.4.0
 
     # https://stackoverflow.com/a/73046084
     Twisted==21.7.0


### PR DESCRIPTION
Requires https://github.com/zytedata/python-zyte-api/pull/32 to be released to PyPI first.

I'm proposing for a `0.5.1` release instead of a `0.6.0` since it's a simply dependency update. Even though we're now enforcing brotli codecs under the hood, in Scrapy's POV, it's a small update and doesn't change anything on how developers directly interact with Zyte API.

TODO after merge:
- Tag `0.5.1` to latest master branch and push.