### PR TITLE
CI: run twine check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10"]
-        tox-job: ["mypy", "flake8"]
+        tox-job: ["mypy", "flake8", "twine-check"]
 
     steps:
     - uses: actions/checkout@v2

--- a/tox.ini
+++ b/tox.ini
@@ -117,3 +117,10 @@ commands =
 [testenv:isort-check]
 deps = {[testenv:isort]deps}
 commands = {[testenv:isort]commands} -c
+
+[testenv:twine-check]
+deps =
+    twine
+commands =
+    python setup.py sdist
+    twine check dist/*


### PR DESCRIPTION
Based on https://github.com/scrapy/scrapy/pull/5656.

It would have detected an issue I introduced into the README.rst as part of https://github.com/scrapy-plugins/scrapy-zyte-api/pull/41, which [I had to fix during the release procedure](https://github.com/scrapy-plugins/scrapy-zyte-api/commit/4c3936f76b5ce36000c1487593356e302bc5bb31#diff-7b3ed02bc73dc06b7db906cf97aa91dec2b2eb21f2d92bc5caa761df5bbc168fR104).