### PR TITLE
Use custom download slots that bypass AutoThrottle

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,9 +15,9 @@ repos:
     hooks:
         - id: flake8
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.971
+    rev: v0.991
     hooks:
     - id: mypy
       additional_dependencies:
       - types-setuptools
-      args: [--ignore-missing-imports, --no-warn-no-return]
+      args: [--check-untyped-defs, --ignore-missing-imports, --no-warn-no-return]

--- a/README.rst
+++ b/README.rst
@@ -48,8 +48,13 @@ To enable this plugin:
     <https://docs.scrapy.org/en/latest/topics/settings.html#std-setting-DOWNLOAD_HANDLERS>`_
     Scrapy setting to ``"scrapy_zyte_api.ScrapyZyteAPIDownloadHandler"``.
 
+-   Add ``"scrapy_zyte_api.ScrapyZyteAPIDownloaderMiddleware"`` to the
+    `DOWNLOADER_MIDDLEWARES
+    <https://docs.scrapy.org/en/latest/topics/settings.html#downloader-middlewares>`_
+    Scrapy setting with any value, e.g. ``1000``.
+
 -   Set the `REQUEST_FINGERPRINTER_CLASS
-    <https://docs.scrapy.org/en/latest/topics/request-response.html#request-fingerprinter-class>`
+    <https://docs.scrapy.org/en/latest/topics/request-response.html#request-fingerprinter-class>`_
     Scrapy setting to ``"scrapy_zyte_api.ScrapyZyteAPIRequestFingerprinter"``.
 
 -   Set the `TWISTED_REACTOR
@@ -69,6 +74,9 @@ For example, in the ``settings.py`` file of your Scrapy project:
     DOWNLOAD_HANDLERS = {
         "http": "scrapy_zyte_api.ScrapyZyteAPIDownloadHandler",
         "https": "scrapy_zyte_api.ScrapyZyteAPIDownloadHandler",
+    }
+    DOWNLOADER_MIDDLEWARES = {
+        "scrapy_zyte_api.ScrapyZyteAPIDownloaderMiddleware": 1000,
     }
     REQUEST_FINGERPRINTER_CLASS = "scrapy_zyte_api.ScrapyZyteAPIRequestFingerprinter"
     TWISTED_REACTOR = "twisted.internet.asyncioreactor.AsyncioSelectorReactor"

--- a/scrapy_zyte_api/__init__.py
+++ b/scrapy_zyte_api/__init__.py
@@ -5,7 +5,6 @@ if _NEEDS_EARLY_REACTOR:
 
     install_reactor("twisted.internet.asyncioreactor.AsyncioSelectorReactor")
 
-from scrapy_zyte_api._request_fingerprinter import (  # NOQA
-    ScrapyZyteAPIRequestFingerprinter,
-)
-from scrapy_zyte_api.handler import ScrapyZyteAPIDownloadHandler  # NOQA
+from ._downloader_middleware import ScrapyZyteAPIDownloaderMiddleware  # NOQA
+from ._request_fingerprinter import ScrapyZyteAPIRequestFingerprinter  # NOQA
+from .handler import ScrapyZyteAPIDownloadHandler  # NOQA

--- a/scrapy_zyte_api/_downloader_middleware.py
+++ b/scrapy_zyte_api/_downloader_middleware.py
@@ -1,0 +1,32 @@
+from typing import Set
+
+from ._params import _ParamParser
+
+
+class ScrapyZyteAPIDownloaderMiddleware:
+
+    _slot_prefix = "zyte-api@"
+
+    @classmethod
+    def from_crawler(cls, crawler):
+        return cls(crawler)
+
+    def __init__(self, crawler) -> None:
+        self._param_parser = _ParamParser(crawler.settings)
+        self._handled_slots: Set[str] = set()
+        self._crawler = crawler
+
+    def process_request(self, request, spider):
+        if self._param_parser.parse(request) is None:
+            return
+
+        downloader = self._crawler.engine.downloader
+        slot_id = downloader._get_slot_key(request, spider)
+        if not slot_id.startswith(self._slot_prefix):
+            slot_id = f"{self._slot_prefix}{slot_id}"
+            request.meta["download_slot"] = slot_id
+        if slot_id in self._handled_slots:
+            return
+        _, slot = downloader._get_slot(request, spider)
+        slot.delay = 0
+        self._handled_slots.add(slot_id)

--- a/scrapy_zyte_api/_downloader_middleware.py
+++ b/scrapy_zyte_api/_downloader_middleware.py
@@ -1,5 +1,3 @@
-from typing import Set
-
 from ._params import _ParamParser
 
 
@@ -13,7 +11,6 @@ class ScrapyZyteAPIDownloaderMiddleware:
 
     def __init__(self, crawler) -> None:
         self._param_parser = _ParamParser(crawler.settings)
-        self._handled_slots: Set[str] = set()
         self._crawler = crawler
 
     def process_request(self, request, spider):
@@ -25,8 +22,5 @@ class ScrapyZyteAPIDownloaderMiddleware:
         if not slot_id.startswith(self._slot_prefix):
             slot_id = f"{self._slot_prefix}{slot_id}"
             request.meta["download_slot"] = slot_id
-        if slot_id in self._handled_slots:
-            return
         _, slot = downloader._get_slot(request, spider)
         slot.delay = 0
-        self._handled_slots.add(slot_id)

--- a/scrapy_zyte_api/_params.py
+++ b/scrapy_zyte_api/_params.py
@@ -456,3 +456,24 @@ def _load_browser_headers(settings):
         {"Referer": "referer"},
     )
     return {k.strip().lower().encode(): v for k, v in browser_headers.items()}
+
+
+class _ParamParser:
+    def __init__(self, settings):
+        self._automap_params = _load_default_params(settings, "ZYTE_API_AUTOMAP_PARAMS")
+        self._browser_headers = _load_browser_headers(settings)
+        self._default_params = _load_default_params(settings, "ZYTE_API_DEFAULT_PARAMS")
+        self._job_id = settings.get("JOB")
+        self._transparent_mode = settings.getbool("ZYTE_API_TRANSPARENT_MODE", False)
+        self._skip_headers = _load_skip_headers(settings)
+
+    def parse(self, request):
+        return _get_api_params(
+            request,
+            default_params=self._default_params,
+            transparent_mode=self._transparent_mode,
+            automap_params=self._automap_params,
+            skip_headers=self._skip_headers,
+            browser_headers=self._browser_headers,
+            job_id=self._job_id,
+        )

--- a/scrapy_zyte_api/_request_fingerprinter.py
+++ b/scrapy_zyte_api/_request_fingerprinter.py
@@ -34,8 +34,7 @@ else:
                 settings=crawler.settings,
                 crawler=crawler,
             )
-            self._cache: "WeakKeyDictionary[Request, bytes]"
-            self._cache = WeakKeyDictionary()
+            self._cache: "WeakKeyDictionary[Request, bytes]" = WeakKeyDictionary()
             self._param_parser = _ParamParser(settings)
             self._skip_keys = (
                 "customHttpRequestHeaders",

--- a/scrapy_zyte_api/_request_fingerprinter.py
+++ b/scrapy_zyte_api/_request_fingerprinter.py
@@ -15,12 +15,7 @@ else:
     from scrapy.utils.misc import create_instance, load_object
     from w3lib.url import canonicalize_url
 
-    from ._params import (
-        _get_api_params,
-        _load_browser_headers,
-        _load_default_params,
-        _load_skip_headers,
-    )
+    from ._params import _ParamParser
 
     class ScrapyZyteAPIRequestFingerprinter:
         @classmethod
@@ -29,17 +24,6 @@ else:
 
         def __init__(self, crawler):
             settings = crawler.settings
-            self._automap_params = _load_default_params(
-                settings, "ZYTE_API_AUTOMAP_PARAMS"
-            )
-            self._browser_headers = _load_browser_headers(settings)
-            self._default_params = _load_default_params(
-                settings, "ZYTE_API_DEFAULT_PARAMS"
-            )
-            self._transparent_mode = settings.getbool(
-                "ZYTE_API_TRANSPARENT_MODE", False
-            )
-            self._skip_headers = _load_skip_headers(settings)
             self._fallback_request_fingerprinter = create_instance(
                 load_object(
                     settings.get(
@@ -52,6 +36,7 @@ else:
             )
             self._cache: "WeakKeyDictionary[Request, bytes]"
             self._cache = WeakKeyDictionary()
+            self._param_parser = _ParamParser(settings)
             self._skip_keys = (
                 "customHttpRequestHeaders",
                 "echoData",
@@ -67,15 +52,7 @@ else:
         def fingerprint(self, request):
             if request in self._cache:
                 return self._cache[request]
-            api_params = _get_api_params(
-                request,
-                default_params=self._default_params,
-                transparent_mode=self._transparent_mode,
-                automap_params=self._automap_params,
-                skip_headers=self._skip_headers,
-                browser_headers=self._browser_headers,
-                job_id=None,
-            )
+            api_params = self._param_parser.parse(request)
             if api_params is not None:
                 api_params["url"] = canonicalize_url(
                     api_params["url"],

--- a/scrapy_zyte_api/handler.py
+++ b/scrapy_zyte_api/handler.py
@@ -16,12 +16,7 @@ from zyte_api.aio.errors import RequestError
 from zyte_api.apikey import NoApiKey
 from zyte_api.constants import API_URL
 
-from ._params import (
-    _get_api_params,
-    _load_browser_headers,
-    _load_default_params,
-    _load_skip_headers,
-)
+from ._params import _ParamParser
 from .responses import ZyteAPIResponse, ZyteAPITextResponse, _process_response
 
 logger = logging.getLogger(__name__)
@@ -65,27 +60,13 @@ class ScrapyZyteAPIDownloadHandler(HTTPDownloadHandler):
         verify_installed_reactor(
             "twisted.internet.asyncioreactor.AsyncioSelectorReactor"
         )
+        self._param_parser = _ParamParser(settings)
+        self._retry_policy = _load_retry_policy(settings)
         self._stats = crawler.stats
         self._session = create_session(connection_pool_size=self._client.n_conn)
 
-        self._automap_params = _load_default_params(settings, "ZYTE_API_AUTOMAP_PARAMS")
-        self._browser_headers = _load_browser_headers(settings)
-        self._default_params = _load_default_params(settings, "ZYTE_API_DEFAULT_PARAMS")
-        self._job_id = crawler.settings.get("JOB")
-        self._retry_policy = _load_retry_policy(settings)
-        self._transparent_mode = settings.getbool("ZYTE_API_TRANSPARENT_MODE", False)
-        self._skip_headers = _load_skip_headers(settings)
-
     def download_request(self, request: Request, spider: Spider) -> Deferred:
-        api_params = _get_api_params(
-            request,
-            default_params=self._default_params,
-            transparent_mode=self._transparent_mode,
-            automap_params=self._automap_params,
-            skip_headers=self._skip_headers,
-            browser_headers=self._browser_headers,
-            job_id=self._job_id,
-        )
+        api_params = self._param_parser.parse(request)
         if api_params is not None:
             return deferred_from_coro(
                 self._download_request(api_params, request, spider)

--- a/scrapy_zyte_api/responses.py
+++ b/scrapy_zyte_api/responses.py
@@ -23,7 +23,7 @@ class ZyteAPIMixin:
         "content-encoding"
     }
 
-    def __init__(self, *args, raw_api_response: Dict = None, **kwargs):
+    def __init__(self, *args, raw_api_response: Optional[Dict] = None, **kwargs):
         super().__init__(*args, **kwargs)
         self._raw_api_response = raw_api_response
         if not _RESPONSE_HAS_ATTRIBUTES:
@@ -118,8 +118,15 @@ class ZyteAPIResponse(ZyteAPIMixin, Response):
         )
 
 
+_IMMUTABLE_JSON = Union[None, str, int, float, bool]
+_JSON = Union[
+    None, str, int, float, bool, List["_JSON"], Dict[_IMMUTABLE_JSON, "_JSON"]
+]
+_API_RESPONSE = Dict[str, _JSON]
+
+
 def _process_response(
-    api_response: Dict[str, Union[List[Dict], str]], request: Request
+    api_response: _API_RESPONSE, request: Request
 ) -> Optional[Union[ZyteAPITextResponse, ZyteAPIResponse]]:
     """Given a Zyte API Response and the ``scrapy.Request`` that asked for it,
     this returns either a ``ZyteAPITextResponse`` or ``ZyteAPIResponse`` depending

--- a/tests/test_downloader_middleware.py
+++ b/tests/test_downloader_middleware.py
@@ -43,13 +43,14 @@ async def test_downloader_middleware():
     _, slot = crawler.engine.downloader._get_slot(request, spider)
     assert slot.delay == 0
 
-    # The slot delay is only set to 0 once per slot, so it is still possible to
-    # change it from custom code if desired.
+    # The slot delay is set to 0 every time a request for the slot is
+    # processed, so even if it gets changed later on somehow, the downloader
+    # middleware will reset it to 0 again the next time it processes a request.
     slot.delay = 10
     request = Request("https://example.com", meta={"zyte_api": {}})
     assert middleware.process_request(request, spider) is None
     assert request.meta["download_slot"] == "zyte-api@example.com"
     _, slot = crawler.engine.downloader._get_slot(request, spider)
-    assert slot.delay == 10
+    assert slot.delay == 0
 
     await crawler.stop()

--- a/tests/test_downloader_middleware.py
+++ b/tests/test_downloader_middleware.py
@@ -1,0 +1,55 @@
+from pytest_twisted import ensureDeferred
+from scrapy import Request
+from scrapy.utils.misc import create_instance
+from scrapy.utils.test import get_crawler
+
+from scrapy_zyte_api import ScrapyZyteAPIDownloaderMiddleware
+
+
+@ensureDeferred
+async def test_downloader_middleware():
+    crawler = get_crawler()
+    await crawler.crawl("a")
+    spider = crawler.spider
+
+    middleware = create_instance(
+        ScrapyZyteAPIDownloaderMiddleware, settings=crawler.settings, crawler=crawler
+    )
+
+    # AutoThrottle does this.
+    spider.download_delay = 5
+
+    # No effect on non-Zyte-API requests
+    request = Request("https://example.com")
+    assert middleware.process_request(request, spider) is None
+    assert "download_slot" not in request.meta
+    _, slot = crawler.engine.downloader._get_slot(request, spider)
+    assert slot.delay == spider.download_delay
+
+    # On Zyte API requests, the download slot is changed, and its delay is set
+    # to 0.
+    request = Request("https://example.com", meta={"zyte_api": {}})
+    assert middleware.process_request(request, spider) is None
+    assert request.meta["download_slot"] == "zyte-api@example.com"
+    _, slot = crawler.engine.downloader._get_slot(request, spider)
+    assert slot.delay == 0
+
+    # Requests that happen to already have the right download slot assigned
+    # work the same.
+    meta = {"download_slot": "zyte-api@example.com", "zyte_api": True}
+    request = Request("https://example.com", meta=meta)
+    assert middleware.process_request(request, spider) is None
+    assert request.meta["download_slot"] == "zyte-api@example.com"
+    _, slot = crawler.engine.downloader._get_slot(request, spider)
+    assert slot.delay == 0
+
+    # The slot delay is only set to 0 once per slot, so it is still possible to
+    # change it from custom code if desired.
+    slot.delay = 10
+    request = Request("https://example.com", meta={"zyte_api": {}})
+    assert middleware.process_request(request, spider) is None
+    assert request.meta["download_slot"] == "zyte-api@example.com"
+    _, slot = crawler.engine.downloader._get_slot(request, spider)
+    assert slot.delay == 10
+
+    await crawler.stop()

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -6,6 +6,7 @@ from scrapy.exceptions import NotSupported
 from scrapy.http import Response, TextResponse
 
 from scrapy_zyte_api.responses import (
+    _API_RESPONSE,
     ZyteAPIResponse,
     ZyteAPITextResponse,
     _process_response,
@@ -205,7 +206,10 @@ def test__process_response_no_body():
     """The _process_response() function should handle missing 'browserHtml' or
     'httpResponseBody'.
     """
-    api_response = {"url": "https://example.com", "product": {"name": "shoes"}}
+    api_response: _API_RESPONSE = {
+        "url": "https://example.com",
+        "product": {"name": "shoes"},
+    }
 
     resp = _process_response(api_response, Request(api_response["url"]))
 
@@ -367,9 +371,9 @@ def test__process_response_non_text():
     """Non-textual responses like images, files, etc. won't have access to the
     css/xpath selectors.
     """
-    api_response = {
+    api_response: _API_RESPONSE = {
         "url": "https://example.com/sprite.gif",
-        "httpResponseBody": b"",
+        "httpResponseBody": "",
         "httpResponseHeaders": [
             {
                 "name": "Content-Type",
@@ -431,4 +435,5 @@ def test_status_code(base_kwargs_func, kwargs, expected_status_code):
     del base_api_response["statusCode"]
     api_response = {**base_api_response, **kwargs}
     response = _process_response(api_response, Request(api_response["url"]))
+    assert response is not None
     assert response.status == expected_status_code

--- a/tox.ini
+++ b/tox.ini
@@ -72,10 +72,10 @@ deps =
 
 [testenv:mypy]
 deps =
-    mypy>=0.921
+    mypy==0.991
     types-setuptools
 
-commands = mypy --ignore-missing-imports --no-warn-no-return scrapy_zyte_api tests
+commands = mypy --check-untyped-defs --ignore-missing-imports --no-warn-no-return scrapy_zyte_api tests
 
 [testenv:flake8]
 deps =


### PR DESCRIPTION
Resolves #53.

Tested manually as well.

I see a lot of aspects that we might want to discuss:
- Should we rename the new downloader middleware after what it does (name suggestions?), or keep this generic name and try to concentrate any downloader middleware code that we may need in the future into this downloader middleware, instead of creating new downloader middlewares?
- Is it OK that the whole Zyte API parameter parsing is done just to determine whether or not Zyte API is used, or should we use a simpler, cheaper implementation for this new purpose?
- Is it OK that we are calling the Zyte API parameter parsing logic 3 times per request now? Should we cache those calls somehow? (I assume weak references to requests are not reliable here, as meta can change, and I am not sure what the best alternative would be)
- Is `zyte-api@` the right prefix for slot IDs? `zyte-api@example.com` looks cool to me, but I wonder if it can be misleading, or if `@` can be problematic.
- Is it OK that we are using private APIs of the Scrapy downloader? Should we try to make upstream to expose them as public APIs, be it before or after this change?
- Should I refactor `_params.py` to turn its functions into methods of its new class, to minimize parameter passing?