### PR TITLE
Reuse AsyncClient where possible

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,17 +18,17 @@ jobs:
       matrix:
         include:
         - python-version: '3.7'
-          toxenv: pinned-scrapy-2.0
+          toxenv: pinned-scrapy-2x0
         - python-version: '3.7'
-          toxenv: pinned-scrapy-2.1
+          toxenv: pinned-scrapy-2x1
         - python-version: '3.7'
-          toxenv: pinned-scrapy-2.3
+          toxenv: pinned-scrapy-2x3
         - python-version: '3.7'
-          toxenv: pinned-scrapy-2.4
+          toxenv: pinned-scrapy-2x4
         - python-version: '3.7'
-          toxenv: pinned-scrapy-2.5
+          toxenv: pinned-scrapy-2x5
         - python-version: '3.7'
-          toxenv: pinned-scrapy-2.6
+          toxenv: pinned-scrapy-2x6
         - python-version: '3.8'
         - python-version: '3.9'
         - python-version: '3.10'

--- a/scrapy_zyte_api/handler.py
+++ b/scrapy_zyte_api/handler.py
@@ -39,6 +39,9 @@ class ScrapyZyteAPIDownloadHandler(HTTPDownloadHandler):
         if not hasattr(crawler, "zyte_api_client"):
             if not client:
                 client = self._build_client(settings)
+            # We keep the client in the crawler object to prevent multiple,
+            # duplicate clients with the same settings to be used.
+            # https://github.com/scrapy-plugins/scrapy-zyte-api/issues/58
             crawler.zyte_api_client = client
         self._client: AsyncClient = crawler.zyte_api_client
         logger.info("Using a Zyte API key starting with %r", self._client.api_key[:7])

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -7,7 +7,7 @@ from scrapy.utils.misc import create_instance
 from scrapy.utils.test import get_crawler
 from zyte_api.aio.client import AsyncClient
 
-from scrapy_zyte_api.handler import _CLIENT_CACHE, ScrapyZyteAPIDownloadHandler
+from scrapy_zyte_api.handler import ScrapyZyteAPIDownloadHandler
 
 _API_KEY = "a"
 
@@ -54,14 +54,3 @@ def set_env(**env_vars):
     finally:
         environ.clear()
         environ.update(old_environ)
-
-
-@contextmanager
-def fresh_client_cache():
-    old_cache = dict(_CLIENT_CACHE)
-    _CLIENT_CACHE.clear()
-    try:
-        yield
-    finally:
-        _CLIENT_CACHE.clear()
-        _CLIENT_CACHE.update(old_cache)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -7,7 +7,7 @@ from scrapy.utils.misc import create_instance
 from scrapy.utils.test import get_crawler
 from zyte_api.aio.client import AsyncClient
 
-from scrapy_zyte_api.handler import ScrapyZyteAPIDownloadHandler
+from scrapy_zyte_api.handler import _CLIENT_CACHE, ScrapyZyteAPIDownloadHandler
 
 _API_KEY = "a"
 
@@ -54,3 +54,14 @@ def set_env(**env_vars):
     finally:
         environ.clear()
         environ.update(old_environ)
+
+
+@contextmanager
+def fresh_client_cache():
+    old_cache = dict(_CLIENT_CACHE)
+    _CLIENT_CACHE.clear()
+    try:
+        yield
+    finally:
+        _CLIENT_CACHE.clear()
+        _CLIENT_CACHE.update(old_cache)

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -298,4 +298,4 @@ def test_single_client():
         settings=crawler.settings,
         crawler=crawler,
     )
-    assert handler1._client == handler2._client
+    assert handler1._client is handler2._client

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,8 @@ deps =
     Twisted==21.7.0
     # https://github.com/scrapy/scrapy/issues/5635
     pyopenssl==22.0.0
+    # https://github.com/aws/aws-sam-cli/issues/4527#issuecomment-1368871248
+    cryptography<39
 
 
 # Earliest supported Scrapy version.


### PR DESCRIPTION
Fixes #58 by keeping a cache of Zyte API client objects, and reusing it.

Known issue: the cache does not take into account `os.environ["ZYTE_API_KEY"]`. It would be weird for that value to change mid-execution, so I think it is OK to ignore this issue. Alternatively, we could make it part of the key and client parameters, rather than passing None if the setting is not defined and letting zyte-api pick it from the environment variable instead.

Alternatives I have considered:
- Going for a singleton for the client object, rather than a cache, which should be fine as long as we do not want to allow the download handler class to be instantiated with a different crawler object during the same execution.
- Making the whole download handler class a wrapper, and having all wrappers reuse a singleton implementation of the whole download handler. Discarded as a rather complex solution for the scope of #58. It actually seems best to me assuming there is no issue in having the same object handle different protocols, and I wonder if we should do this in Scrapy’s download handler itself.
- Sharing the stats object instead. To avoid using private API, it requires changes in zyte-api to allow passing stats by parameter to the `__init__` method of the client class. But I see no point in this approach if using the same client also works, since the latter is easier to implement and avoids additional run-time duplicity.
- Having the stat update method somehow aggregate the stats from all running clients. It seems rather complicated compared to any other solution.

Note: I have only addressed mypy issues that seemed related to these specific changes, anything else should hopefully be addressed by #59.