### PR TITLE
Readme fix zyte_api_automap code snippet

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -243,9 +243,7 @@ For example:
             yield scrapy.Request(
                 url="https://quotes.toscrape.com/",
                 meta={
-                    "zyte_api": {
-                        "zyte_api_automap": True,
-                    }
+                    "zyte_api_automap": True,
                 },
             )
 

--- a/README.rst
+++ b/README.rst
@@ -365,9 +365,7 @@ parameters are chosen as follows by default:
             Request(
                 url="https://toscrape.com/img/zyte.png",
                 meta={
-                    "zyte_api": {
-                        "zyte_api_automap": {"httpResponseBody": True},
-                    }
+                    "zyte_api_automap": {"httpResponseBody": True},
                 },
             )
 
@@ -385,9 +383,7 @@ parameters are chosen as follows by default:
             Request(
                 url="https://toscrape.com/",
                 meta={
-                    "zyte_api": {
-                        "zyte_api_automap": {"httpResponseHeaders": True},
-                    }
+                    "zyte_api_automap": {"httpResponseHeaders": True},
                 },
             )
 


### PR DESCRIPTION
I may be wrong, I don't think so but who knows.

I tried zyte_api_automap as the snippet of the Readme said to do. It broke.
When I added directly to `Request.meta`, as the description says, it worked and the `Response` got the `raw_api_response` field as expected.