### PR TITLE
Add release notes for scrapy-zyte-api 0.8.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,16 @@
 Changes
 =======
 
+0.8.1 (to be released)
+----------------------
+
+* Fixed an ``AssertionError`` when cookies are disabled.
+
+* Added links to the README to improve navigation from GitHub.
+
+* Added a license file (BSD-3-Clause).
+
+
 0.8.0 (2023-03-28)
 ------------------
 


### PR DESCRIPTION
Given #74, I think it may be worth not waiting for #76.