### PR TITLE
Support upcoming automatic extraction properties

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -484,10 +484,10 @@ You may set the ``zyte_api_automap`` key in
 to a ``dict`` of Zyte API parameters to extend or override choices made by
 automated request parameter mapping.
 
-Setting ``browserHtml`` or ``screenshot`` to ``True`` unsets
-``httpResponseBody`` and ``httpResponseHeaders``, and makes ``Request.headers``
-become ``requestHeaders`` instead of ``customHttpRequestHeaders``. For example,
-the following Scrapy request:
+Enabling ``browserHtml``, ``screenshot``, or an automatic extraction property,
+unsets ``httpResponseBody`` and ``httpResponseHeaders``, and makes
+``Request.headers`` become ``requestHeaders`` instead of
+``customHttpRequestHeaders``. For example, the following Scrapy request:
 
 .. code-block:: python
 
@@ -780,9 +780,9 @@ extensions, these 2 requests would still be considered identical.
 Logging request parameters
 ==========================
 
-Set the ``ZYTE_API_LOG_REQUESTS`` setting to ``True`` to enable the logging of
-debug messages that indicate the JSON object sent on every extract request to
-Zyte API.
+Set the ``ZYTE_API_LOG_REQUESTS`` setting to ``True`` and the ``LOG_LEVEL``
+setting to ``"DEBUG"`` to enable the logging of debug messages that indicate
+the JSON object sent on every extract request to Zyte API.
 
 For example::
 

--- a/scrapy_zyte_api/_params.py
+++ b/scrapy_zyte_api/_params.py
@@ -13,10 +13,16 @@ from ._cookies import _get_all_cookies
 
 logger = getLogger(__name__)
 
-_DEFAULT_API_PARAMS = {
-    "browserHtml": False,
-    "screenshot": False,
+_EXTRACT_KEYS = {
+    "article",
+    "articleList",
+    "articleNavigation",
+    "product",
+    "productList",
+    "productNavigation",
 }
+_BROWSER_KEYS = _EXTRACT_KEYS | {"browserHtml", "screenshot"}
+_DEFAULT_API_PARAMS = {key: False for key in _BROWSER_KEYS}
 
 
 def _iter_headers(
@@ -133,10 +139,7 @@ def _set_request_headers_from_request(
         api_params.pop("customHttpRequestHeaders")
 
     if (
-        (
-            not response_body
-            or any(api_params.get(k) for k in ("browserHtml", "screenshot"))
-        )
+        (not response_body or any(api_params.get(k) for k in _BROWSER_KEYS))
         and request_headers is not False
         or request_headers is True
     ):
@@ -154,9 +157,7 @@ def _set_http_response_body_from_request(
     api_params: Dict[str, Any],
     request: Request,
 ):
-    if not any(
-        api_params.get(k) for k in ("httpResponseBody", "browserHtml", "screenshot")
-    ):
+    if not any(api_params.get(k) for k in _BROWSER_KEYS):
         api_params.setdefault("httpResponseBody", True)
     elif api_params.get("httpResponseBody") is False:
         logger.warning(


### PR DESCRIPTION
I basically searched `test_api_requests.py` for `screenshot`, and added similar test cases for one of the automatic extraction properties. The main point is to not have `httpResponseBody` automatically set when one of the automatic extraction properties is used, so I think this is enough.

In the future we might want to give a nicer way to access the returned data than `response.raw_api_response["field"]`, but I think that is out of scope here.