### PR TITLE
Cache provider output per request

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,3 +7,11 @@ def mockserver():
 
     with MockServer() as server:
         yield server
+
+
+@pytest.fixture(scope="function")
+def fresh_mockserver():
+    from .mockserver import MockServer
+
+    with MockServer() as server:
+        yield server


### PR DESCRIPTION
As a side effect, it allows to work around https://github.com/scrapy-plugins/scrapy-zyte-api/issues/91 by requesting indirect outputs directly on the spider callback as well.