### PR TITLE
Introduce ZYTE_API_MAX_REQUESTS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -723,6 +723,19 @@ as HTTP 520 errors, you can implement:
 .. _tenacity.AsyncRetrying: https://tenacity.readthedocs.io/en/latest/api.html#tenacity.AsyncRetrying
 
 
+Misc Settings
+=============
+
+- ``ZYTE_API_MAX_REQUESTS``
+
+  default: None
+
+  When set to an integer value > 0, the spider will close when the number of
+  successful Zyte API requests reaches it. Note that in some cases, the actual
+  number of successful Zyte API requests would be below this number if some of
+  the in-progress requests fail or error out.
+
+
 Stats
 =====
 

--- a/README.rst
+++ b/README.rst
@@ -723,12 +723,12 @@ as HTTP 520 errors, you can implement:
 .. _tenacity.AsyncRetrying: https://tenacity.readthedocs.io/en/latest/api.html#tenacity.AsyncRetrying
 
 
-Misc Settings
+Misc settings
 =============
 
 - ``ZYTE_API_MAX_REQUESTS``
 
-  default: None
+  Default: ``None``
 
   When set to an integer value > 0, the spider will close when the number of
   successful Zyte API requests reaches it. Note that in some cases, the actual

--- a/scrapy_zyte_api/_downloader_middleware.py
+++ b/scrapy_zyte_api/_downloader_middleware.py
@@ -1,4 +1,10 @@
+import logging
+
+from scrapy.exceptions import IgnoreRequest
+
 from ._params import _ParamParser
+
+logger = logging.getLogger(__name__)
 
 
 class ScrapyZyteAPIDownloaderMiddleware:
@@ -12,6 +18,13 @@ class ScrapyZyteAPIDownloaderMiddleware:
         self._param_parser = _ParamParser(crawler, cookies_enabled=False)
         self._crawler = crawler
 
+        self._max_requests = crawler.settings.getint("ZYTE_API_MAX_REQUESTS")
+        if self._max_requests:
+            logger.info(
+                f"Maximum Zyte API requests for this crawl is set at "
+                f"{self._max_requests}. Spider will close when it's reached."
+            )
+
     def process_request(self, request, spider):
         if self._param_parser.parse(request) is None:
             return
@@ -23,3 +36,24 @@ class ScrapyZyteAPIDownloaderMiddleware:
             request.meta["download_slot"] = slot_id
         _, slot = downloader._get_slot(request, spider)
         slot.delay = 0
+
+        if (
+            self._max_requests
+            and self._zapi_req_count() + self._download_req_count(downloader)
+            >= self._max_requests
+        ):
+            self._crawler.engine.close_spider(spider, "closespider_max_zapi_requests")
+            self._crawler.engine.downloader.close()
+            raise IgnoreRequest("Reached max Zyte API requests")
+
+    def _zapi_req_count(self) -> int:
+        return self._crawler.stats.get_value("scrapy-zyte-api/processed", 0)
+
+    def _download_req_count(self, downloader) -> int:
+        return sum(
+            [
+                len(slot.transferring)
+                for slot_id, slot in downloader.slots.items()
+                if slot_id.startswith(self._slot_prefix)
+            ]
+        )

--- a/scrapy_zyte_api/_downloader_middleware.py
+++ b/scrapy_zyte_api/_downloader_middleware.py
@@ -22,7 +22,8 @@ class ScrapyZyteAPIDownloaderMiddleware:
         if self._max_requests:
             logger.info(
                 f"Maximum Zyte API requests for this crawl is set at "
-                f"{self._max_requests}. Spider will close when it's reached."
+                f"{self._max_requests}. The spider will close when it's "
+                f"reached."
             )
 
     def process_request(self, request, spider):

--- a/scrapy_zyte_api/_downloader_middleware.py
+++ b/scrapy_zyte_api/_downloader_middleware.py
@@ -39,7 +39,10 @@ class ScrapyZyteAPIDownloaderMiddleware:
 
         if self._max_requests_reached(downloader):
             self._crawler.engine.close_spider(spider, "closespider_max_zapi_requests")
-            raise IgnoreRequest("Reached max Zyte API requests")
+            raise IgnoreRequest(
+                f"The request {request} is skipped as {self._max_requests} max "
+                f"Zyte API requests have been reached."
+            )
 
     def _max_requests_reached(self, downloader) -> bool:
         if not self._max_requests:

--- a/tests/test_downloader_middleware.py
+++ b/tests/test_downloader_middleware.py
@@ -1,9 +1,13 @@
 from pytest_twisted import ensureDeferred
-from scrapy import Request
+from scrapy import Request, Spider
+from scrapy.item import Item
 from scrapy.utils.misc import create_instance
 from scrapy.utils.test import get_crawler
 
 from scrapy_zyte_api import ScrapyZyteAPIDownloaderMiddleware
+
+from . import SETTINGS
+from .mockserver import DelayedResource, MockServer
 
 
 @ensureDeferred
@@ -72,3 +76,51 @@ async def test_cookies():
     )
     assert middleware.process_request(request, spider) is None
     assert request.meta["download_slot"] == "zyte-api@example.com"
+
+
+@ensureDeferred
+async def test_max_requests(caplog):
+    spider_requests = 200
+    zapi_max_requests = 5
+
+    with MockServer(DelayedResource) as server:
+
+        class TestSpider(Spider):
+            name = "test_spider"
+
+            def start_requests(self):
+                # TODO: try a lower number as well close to max requests count
+                for index in range(spider_requests):
+                    yield Request("https://example.com", dont_filter=True)
+
+            def parse(self, response):
+                yield Item()
+
+        settings = {
+            "DOWNLOADER_MIDDLEWARES": {
+                "scrapy_zyte_api.ScrapyZyteAPIDownloaderMiddleware": 1000
+            },
+            "ZYTE_API_MAX_REQUESTS": zapi_max_requests,
+            "ZYTE_API_TRANSPARENT_MODE": True,
+            "ZYTE_API_URL": server.urljoin("/"),
+            **SETTINGS,
+        }
+
+        crawler = get_crawler(TestSpider, settings_dict=settings)
+        with caplog.at_level("INFO"):
+            await crawler.crawl()
+
+    assert (
+        f"Maximum Zyte API requests for this crawl is set at {zapi_max_requests}"
+        in caplog.text
+    )
+    assert crawler.stats.get_value("scrapy-zyte-api/success") <= zapi_max_requests
+    assert crawler.stats.get_value("scrapy-zyte-api/processed") == zapi_max_requests
+    assert crawler.stats.get_value("item_scraped_count") == zapi_max_requests
+    assert crawler.stats.get_value("finish_reason") == "closespider_max_zapi_requests"
+    assert (
+        crawler.stats.get_value(
+            "downloader/exception_type_count/scrapy.exceptions.IgnoreRequest"
+        )
+        > 0
+    )


### PR DESCRIPTION
An attempt on https://github.com/scrapy-plugins/scrapy-zyte-api/issues/111 to gather feedback.

This has minimal changes that only addresses the limits on ZAPI Requests.

In the future, we also might want to impose other limits like the following which may affect the implementation:
- item count
- per data type 
- per page type
- etc

TODO
- [x] README