### PR TITLE
Test the minimum dependencies of the provider extra

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,9 @@ jobs:
         - python-version: '3.9'
         - python-version: '3.10'
         - python-version: '3.11'
+
+        - python-version: '3.8'
+          toxenv: pinned-provider
         - python-version: '3.11'
           toxenv: provider
 

--- a/setup.py
+++ b/setup.py
@@ -10,12 +10,14 @@ setuptools.setup(
     author_email="info@zyte.com",
     url="https://github.com/scrapy-plugins/scrapy-zyte-api",
     packages=["scrapy_zyte_api"],
+    # Sync with [pinned] @ tox.ini
     install_requires=[
         "packaging>=20.0",
         "scrapy>=2.0.1",
         "zyte-api>=0.4.0",
     ],
     extras_require={
+        # Sync with [testenv:provider-pinned] @ tox.ini
         "provider": [
             "scrapy-poet>=0.10.0",
             "web-poet>=0.13.0",

--- a/tox.ini
+++ b/tox.ini
@@ -80,6 +80,17 @@ deps =
 [testenv:provider]
 extras = provider
 
+[testenv:pinned-provider]
+# zyte-common-items ≥ 0.6.0 requires Python ≥ 3.8.
+basepython=python3.8
+extras = provider
+deps =
+    # scrapy-poet 0.10.0 depends on scrapy>=2.6.0
+    {[testenv:pinned-scrapy-2x6]deps}
+    scrapy-poet==0.10.0
+    web-poet==0.13.0
+    zyte-common-items==0.7.0
+
 [testenv:mypy]
 deps =
     mypy==1.4.1


### PR DESCRIPTION
Note: I was hoping this would have caused the accidental scrapy-poet dependency upgrade to fail, but it turns out the test would simply have upgraded the dependency while installing the package inside the tox environment, and passed nonetheless.