### PR TITLE
change ellipsis to 3 dots for ZYTE_API_LOG_REQUESTS text truncation

### DIFF
--- a/scrapy_zyte_api/handler.py
+++ b/scrapy_zyte_api/handler.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 def _truncate_str(obj, index, text, limit):
     if len(text) <= limit:
         return
-    obj[index] = text[: limit - 1] + "…"
+    obj[index] = text[: limit - 1] + "..."
 
 
 def _truncate(obj, limit):

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -247,7 +247,9 @@ async def test_stats(mockserver):
         scrapy_stats = handler._stats
         assert scrapy_stats.get_stats() == {}
 
-        meta = {"zyte_api": {"a": "…", "b": {"b0": "…"}, "experimental": {"c0": "…"}}}
+        meta = {
+            "zyte_api": {"a": "...", "b": {"b0": "..."}, "experimental": {"c0": "..."}}
+        }
         request = Request("https://example.com", meta=meta)
         await handler.download_request(request, None)
 
@@ -342,10 +344,10 @@ async def test_log_request_toggle(
 @pytest.mark.parametrize(
     "settings,short_str,long_str,truncated_str",
     [
-        ({}, "a" * 64, "a" * 65, "a" * 63 + "…"),
+        ({}, "a" * 64, "a" * 65, "a" * 63 + "..."),
         ({"ZYTE_API_LOG_REQUESTS_TRUNCATE": 0}, "a" * 64, "a" * 65, "a" * 65),
-        ({"ZYTE_API_LOG_REQUESTS_TRUNCATE": 1}, "a", "aa", "…"),
-        ({"ZYTE_API_LOG_REQUESTS_TRUNCATE": 2}, "aa", "aaa", "a…"),
+        ({"ZYTE_API_LOG_REQUESTS_TRUNCATE": 1}, "a", "aa", "..."),
+        ({"ZYTE_API_LOG_REQUESTS_TRUNCATE": 2}, "aa", "aaa", "a..."),
     ],
 )
 async def test_log_request_truncate(


### PR DESCRIPTION
Motivation: I got confused when looking at the Scrapy Cloud logs since it says I got a request on http://books.toscrape.com/catalogue/category/books/romance_8/in\u2026

Log example:
```
[scrapy_zyte_api.handler] Sending Zyte API extract request: {"httpResponseBody": true, "httpResponseHeaders": true,
 "customHttpRequestHeaders": [{"name": "Referer", "value": "http://books.toscrape.com/"}, {"name": "Accept", "value": 
"text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"}, {"name": "Accept-Language", "value": "en"}, {"name": 
"Accept-Encoding", "value": "gzip, deflate, br"}], "jobId": "633164/22/65", "url": 
"http://books.toscrape.com/catalogue/category/books/romance_8/in\u2026"}
```

It turns out this `\u2026` character was the `…` ellipsis character. What do you think about changing this to 3 dots instead?