### PR TITLE
Remove unused extration options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -950,6 +950,18 @@ in ``settings.py``::
 
     ZYTE_API_PROVIDER_PARAMS = {"geolocation": "IE"}
 
+When ``ZYTE_API_PROVIDER_PARAMS`` setting includes one of the Zyte API
+extraction options (e.g. ``productOptions`` for ``product``), but the
+final Zyte API request doesn't include the corresponding data type, the
+unused options are automatically removed. So, it's safe to use
+``ZYTE_API_PROVIDER_PARAMS`` to set the default options for various extraction
+types, e.g.::
+
+    ZYTE_API_PROVIDER_PARAMS = {
+        "productOptions": {"extractFrom": "httpResponseBody"},
+        "productNavigationOptions": {"extractFrom": "httpResponseBody"},
+    }
+
 Note that the built-in ``scrapy_poet.page_input_providers.ItemProvider`` has a
 priority of 2000, so when you have page objects producing
 ``zyte_common_items.Product`` items you should use higher values for

--- a/README.rst
+++ b/README.rst
@@ -950,7 +950,7 @@ in ``settings.py``::
 
     ZYTE_API_PROVIDER_PARAMS = {"geolocation": "IE"}
 
-When ``ZYTE_API_PROVIDER_PARAMS`` setting includes one of the Zyte API
+When the ``ZYTE_API_PROVIDER_PARAMS`` setting includes one of the Zyte API
 extraction options (e.g. ``productOptions`` for ``product``), but the
 final Zyte API request doesn't include the corresponding data type, the
 unused options are automatically removed. So, it's safe to use

--- a/scrapy_zyte_api/providers.py
+++ b/scrapy_zyte_api/providers.py
@@ -78,6 +78,11 @@ class ZyteApiProvider(PageObjectInputProvider):
         for item_type, kw in item_keywords.items():
             if item_type in to_provide:
                 zyte_api_meta[kw] = True
+            else:
+                options_name = f"{kw}Options"
+                if options_name in zyte_api_meta:
+                    del zyte_api_meta[options_name]
+
         api_request = Request(
             url=request.url,
             meta={

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -179,3 +179,22 @@ async def test_provider_params(mockserver):
     _, _, crawler = await crawl_single_item(ZyteAPISpider, HtmlResource, settings)
     assert crawler.stats.get_value("scrapy-zyte-api/request_args/browserHtml") == 1
     assert crawler.stats.get_value("scrapy-zyte-api/request_args/geolocation") == 1
+
+
+@ensureDeferred
+async def test_provider_params_remove_unused_options(mockserver):
+    settings = create_scrapy_settings(None)
+    settings.update(SETTINGS)
+    settings["ZYTE_API_URL"] = mockserver.urljoin("/")
+    settings["SCRAPY_POET_PROVIDERS"] = {ZyteApiProvider: 0}
+    settings["ZYTE_API_PROVIDER_PARAMS"] = {
+        "productOptions": {"extractFrom": "httpResponseBody"},
+        "productNavigationOptions": {"extractFrom": "httpResponseBody"},
+    }
+    _, _, crawler = await crawl_single_item(ZyteAPISpider, Product, settings)
+    assert crawler.stats.get_value("scrapy-zyte-api/request_args/product") == 1
+    assert crawler.stats.get_value("scrapy-zyte-api/request_args/productOptions") == 1
+    assert (
+        crawler.stats.get_value("scrapy-zyte-api/request_args/productNavigationOptions")
+        is None
+    )


### PR DESCRIPTION
I'm not 100% sure it's a right thing to do, but it doesn't seem it hurts.
This change allows to set

```
        "ZYTE_API_PROVIDER_PARAMS": {
            "productOptions": {"extractFrom": "httpResponseBody"},
            "productNavigationOptions": {"extractFrom": "httpResponseBody"},
        }

```

option, and not having the client to pass the unused ...Options parameters to the API (which fails API validation).