### PR TITLE
Fail on SPM + transparent mode

### DIFF
--- a/scrapy_zyte_api/handler.py
+++ b/scrapy_zyte_api/handler.py
@@ -62,6 +62,29 @@ class ScrapyZyteAPIDownloadHandler(HTTPDownloadHandler):
             raise NotConfigured(
                 "Zyte API is disabled. Set ZYTE_API_ENABLED to True to enable it."
             )
+        if settings.getbool("ZYTE_API_TRANSPARENT_MODE", False) and (
+            settings.getbool("ZYTE_SMARTPROXY_ENABLED", False)
+            or settings.getbool("CRAWLERA_ENABLED", False)
+        ):
+            spm_setting = (
+                "ZYTE_SMARTPROXY_ENABLED"
+                if settings.getbool("ZYTE_SMARTPROXY_ENABLED", False)
+                else "CRAWLERA_ENABLED"
+            )
+            raise NotConfigured(
+                f"Both ZYTE_API_TRANSPARENT_MODE and {spm_setting} are "
+                f"enabled. You should only enable one of those at the same "
+                f"time.\n"
+                f"\n"
+                f"To combine requests that use Zyte API and requests that use "
+                f"Zyte Smart Proxy Manager in the same spider:\n"
+                f"\n"
+                f"1. Leave {spm_setting} as True.\n"
+                f"2. Unset ZYTE_API_TRANSPARENT_MODE or set it to False.\n"
+                f"3. To send a specific request through Zyte API, use "
+                f"request.meta to set dont_proxy to True and zyte_api_automap "
+                f"either to True or to a dictionary of extra request fields."
+            )
         if not hasattr(crawler, "zyte_api_client"):
             if not client:
                 client = self._build_client(settings)

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -556,3 +556,23 @@ async def test_suspended_account_callback():
         await crawler.crawl()
 
     assert crawler.stats.get_value("finish_reason") == "zyte_api_suspended_account"
+
+
+@pytest.mark.parametrize(
+    "spm_setting",
+    ("ZYTE_SMARTPROXY_ENABLED", "CRAWLERA_ENABLED"),
+)
+def test_spm_conflict(spm_setting):
+    settings = {
+        "ZYTE_API_TRANSPARENT_MODE": True,
+        spm_setting: True,
+        **SETTINGS,
+    }
+    crawler = get_crawler(settings_dict=settings)
+
+    with pytest.raises(NotConfigured):
+        create_instance(
+            ScrapyZyteAPIDownloadHandler,
+            settings=None,
+            crawler=crawler,
+        )


### PR DESCRIPTION
I went with raising `NotConfigured` from the handlers.

However, I wonder if instead we should treat this as a fatal error and close the spider with a custom reason.

In fact, I wonder if we should do that for other `NotConfigured` errors in the handler, since some users have a hard time figuring out those kind of issues from the logs, and a non-working HTTP/HTTPS handler feels like a critical-enough issue to warrant closing the spider until it is addressed.