### PR TITLE
add request count to max requests close reason

### DIFF
--- a/scrapy_zyte_api/_middlewares.py
+++ b/scrapy_zyte_api/_middlewares.py
@@ -108,7 +108,9 @@ class ScrapyZyteAPIDownloaderMiddleware:
         slot.delay = 0
 
         if self._max_requests_reached(downloader):
-            self._crawler.engine.close_spider(spider, "closespider_max_zapi_requests")
+            self._crawler.engine.close_spider(
+                spider, f"closespider_max_{self._max_requests}_zapi_requests"
+            )
             raise IgnoreRequest(
                 f"The request {request} is skipped as {self._max_requests} max "
                 f"Zyte API requests have been reached."

--- a/tests/test_middlewares.py
+++ b/tests/test_middlewares.py
@@ -133,7 +133,10 @@ async def test_max_requests(caplog):
     assert crawler.stats.get_value("scrapy-zyte-api/success") <= zapi_max_requests
     assert crawler.stats.get_value("scrapy-zyte-api/processed") == zapi_max_requests
     assert crawler.stats.get_value("item_scraped_count") == zapi_max_requests + 6
-    assert crawler.stats.get_value("finish_reason") == "closespider_max_zapi_requests"
+    assert (
+        crawler.stats.get_value("finish_reason")
+        == f"closespider_max_{zapi_max_requests}_zapi_requests"
+    )
     assert (
         crawler.stats.get_value(
             "downloader/exception_type_count/scrapy.exceptions.IgnoreRequest"


### PR DESCRIPTION
When looking at the list of spider jobs in Scrapy Cloud, there's a column dictating the spider's `close_reason` message. Some users have raised that it's not apparently clear from this view about the max request that was set.

What do you think about including the set number of max requests to the spider `close_reason` message?

<img width="254" alt="image" src="https://github.com/scrapy-plugins/scrapy-zyte-api/assets/3449761/d463784d-db17-4400-9925-9ac6f1739b96">
