### PR TITLE
Support scrapy-poet fingerprinting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Unreleased
 
 * Updated requirement versions:
 
-  * scrapy-poet >= 0.20.0
+  * scrapy-poet >= 0.20.1
 
 
 0.14.1 (2024-01-17)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Changes
 =======
 
+Unreleased
+----------
+
+* Updated requirement versions:
+
+  * scrapy-poet >= 0.20.0
+
+
 0.14.1 (2024-01-17)
 -------------------
 

--- a/docs/reference/settings.rst
+++ b/docs/reference/settings.rst
@@ -117,7 +117,8 @@ See :ref:`request-automatic`.
 ZYTE_API_FALLBACK_REQUEST_FINGERPRINTER_CLASS
 =============================================
 
-Default: :class:`scrapy.utils.request.RequestFingerprinter`
+Default: :class:`scrapy_poet.ScrapyPoetRequestFingerprinter` if scrapy-poet is
+installed, else :class:`scrapy.utils.request.RequestFingerprinter`
 
 :ref:`Request fingerprinter <request-fingerprints>` to for requests that do not
 go through Zyte API. See :ref:`fingerprint`.

--- a/scrapy_zyte_api/_request_fingerprinter.py
+++ b/scrapy_zyte_api/_request_fingerprinter.py
@@ -3,8 +3,8 @@ from typing import TYPE_CHECKING
 
 logger = getLogger(__name__)
 
-try:
-    from scrapy.utils.request import RequestFingerprinter  # NOQA
+try:  # noqa: C901
+    from scrapy.utils.request import RequestFingerprinter as _  # noqa: F401
 except ImportError:
     if not TYPE_CHECKING:
         ScrapyZyteAPIRequestFingerprinter = None

--- a/scrapy_zyte_api/_request_fingerprinter.py
+++ b/scrapy_zyte_api/_request_fingerprinter.py
@@ -1,4 +1,7 @@
+from logging import getLogger
 from typing import TYPE_CHECKING
+
+logger = getLogger(__name__)
 
 try:
     from scrapy.utils.request import RequestFingerprinter  # NOQA
@@ -12,7 +15,9 @@ else:
     from weakref import WeakKeyDictionary
 
     from scrapy import Request
-    from scrapy.settings.default_settings import REQUEST_FINGERPRINTER_CLASS
+    from scrapy.settings.default_settings import (
+        REQUEST_FINGERPRINTER_CLASS as ScrapyRequestFingerprinter,
+    )
     from scrapy.utils.misc import create_instance, load_object
     from w3lib.url import canonicalize_url
 
@@ -25,16 +30,43 @@ else:
 
         def __init__(self, crawler):
             settings = crawler.settings
+            try:
+                from scrapy_poet import ScrapyPoetRequestFingerprinter
+            except ImportError:
+                self._has_poet = False
+                RequestFingerprinter = ScrapyRequestFingerprinter
+            else:
+                self._has_poet = True
+                RequestFingerprinter = ScrapyPoetRequestFingerprinter
             self._fallback_request_fingerprinter = create_instance(
                 load_object(
                     settings.get(
                         "ZYTE_API_FALLBACK_REQUEST_FINGERPRINTER_CLASS",
-                        REQUEST_FINGERPRINTER_CLASS,
+                        RequestFingerprinter,
                     )
                 ),
                 settings=crawler.settings,
                 crawler=crawler,
             )
+            if self._has_poet and not isinstance(
+                self._fallback_request_fingerprinter, RequestFingerprinter
+            ):
+                logger.warning(
+                    f"You have scrapy-poet installed, but your custom value "
+                    f"for the ZYTE_API_FALLBACK_REQUEST_FINGERPRINTER_CLASS "
+                    f"setting "
+                    f"({settings['ZYTE_API_FALLBACK_REQUEST_FINGERPRINTER_CLASS']!r})"
+                    f" does not point to a subclass of "
+                    f"scrapy_poet.ScrapyPoetRequestFingerprinter. For request "
+                    f"fingerprinting to work properly, consider switching "
+                    f"ZYTE_API_FALLBACK_REQUEST_FINGERPRINTER_CLASS to "
+                    f"scrapy_poet.ScrapyPoetRequestFingerprinter or a "
+                    f"subclass. You can move your current value of the "
+                    f"ZYTE_API_FALLBACK_REQUEST_FINGERPRINTER_CLASS setting "
+                    f"to the SCRAPY_POET_REQUEST_FINGERPRINTER_BASE_CLASS "
+                    f"setting instead."
+                )
+                self._has_poet = False
             self._cache: "WeakKeyDictionary[Request, bytes]" = WeakKeyDictionary()
             self._param_parser = _ParamParser(crawler, cookies_enabled=False)
 
@@ -59,7 +91,20 @@ else:
             api_params = self._param_parser.parse(request)
             if api_params is not None:
                 self._normalize_params(api_params)
-                fingerprint_json = json.dumps(api_params, sort_keys=True)
-                self._cache[request] = hashlib.sha1(fingerprint_json.encode()).digest()
+                fingerprint = json.dumps(api_params, sort_keys=True).encode()
+                if self._has_poet:
+                    deps_key = self._fallback_request_fingerprinter.get_deps_key(
+                        request
+                    )
+                    serialized_page_params = (
+                        self._fallback_request_fingerprinter.serialize_page_params(
+                            request
+                        )
+                    )
+                    if deps_key is not None:
+                        fingerprint += deps_key
+                    if serialized_page_params is not None:
+                        fingerprint += serialized_page_params
+                self._cache[request] = hashlib.sha1(fingerprint).digest()
                 return self._cache[request]
             return self._fallback_request_fingerprinter.fingerprint(request)

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,7 @@ setuptools.setup(
         # Sync with [testenv:pinned-provider] @ tox.ini
         "provider": [
             "andi>=0.6.0",
-            # "scrapy-poet>=0.20.0",
-            "scrapy-poet @ git+https://github.com/Gallaecio/scrapy-poet.git@scrapy-zte-api-fixes",
+            "scrapy-poet>=0.20.1",
             "web-poet>=0.15.1",
             "zyte-common-items>=0.8.0",
         ]

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,8 @@ setuptools.setup(
         # Sync with [testenv:pinned-provider] @ tox.ini
         "provider": [
             "andi>=0.6.0",
-            "scrapy-poet>=0.19.0",
+            # "scrapy-poet>=0.20.0",
+            "scrapy-poet @ git+https://github.com/Gallaecio/scrapy-poet.git@scrapy-zte-api-fixes",
             "web-poet>=0.15.1",
             "zyte-common-items>=0.8.0",
         ]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -33,6 +33,7 @@ try:
 except ImportError:
     pass
 else:
+    assert isinstance(SETTINGS["DOWNLOADER_MIDDLEWARES"], dict)
     SETTINGS["DOWNLOADER_MIDDLEWARES"]["scrapy_poet.InjectionMiddleware"] = 543
 UNSET = object()
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -29,7 +29,7 @@ SETTINGS = {
     "TWISTED_REACTOR": "twisted.internet.asyncioreactor.AsyncioSelectorReactor",
 }
 try:
-    import scrapy_poet
+    import scrapy_poet  # noqa: F401
 except ImportError:
     pass
 else:
@@ -43,6 +43,7 @@ class DummySpider(Spider):
 
 def get_crawler(settings=None, spider_cls=DummySpider, setup_engine=True):
     settings = settings or {}
+    settings = {**SETTINGS, **settings}
     crawler = _get_crawler(settings_dict=settings, spidercls=spider_cls)
     if setup_engine:
         setup_crawler_engine(crawler)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -28,6 +28,12 @@ SETTINGS = {
     "ZYTE_API_KEY": _API_KEY,
     "TWISTED_REACTOR": "twisted.internet.asyncioreactor.AsyncioSelectorReactor",
 }
+try:
+    import scrapy_poet
+except ImportError:
+    pass
+else:
+    SETTINGS["DOWNLOADER_MIDDLEWARES"]["scrapy_poet.InjectionMiddleware"] = 543
 UNSET = object()
 
 

--- a/tests/test_api_requests.py
+++ b/tests/test_api_requests.py
@@ -30,7 +30,6 @@ from scrapy_zyte_api.responses import _process_response
 
 from . import (
     DEFAULT_CLIENT_CONCURRENCY,
-    SETTINGS,
     get_crawler,
     get_download_handler,
     get_downloader_middleware,
@@ -252,7 +251,6 @@ async def test_higher_concurrency():
 
         crawler = get_crawler(
             {
-                **SETTINGS,
                 "CONCURRENT_REQUESTS": concurrency,
                 "CONCURRENT_REQUESTS_PER_DOMAIN": concurrency,
                 "ZYTE_API_URL": server.urljoin("/"),
@@ -432,7 +430,7 @@ def test_transparent_mode_toggling(setting, meta, expected):
     :func:`~scrapy_zyte_api.handler._get_api_params` parameter.
     """
     request = Request(url="https://example.com", meta=meta)
-    settings = {**SETTINGS, "ZYTE_API_TRANSPARENT_MODE": setting}
+    settings = {"ZYTE_API_TRANSPARENT_MODE": setting}
     crawler = get_crawler(settings)
     handler = get_download_handler(crawler, "https")
     param_parser = handler._param_parser
@@ -487,7 +485,7 @@ async def test_job_id(meta, mockserver):
     """
     request = Request(url="https://example.com", meta={meta: True})
     with set_env(SHUB_JOBKEY="1/2/3"):
-        crawler = get_crawler(SETTINGS)
+        crawler = get_crawler()
         handler = get_download_handler(crawler, "https")
         param_parser = handler._param_parser
         api_params = param_parser.parse(request)
@@ -572,8 +570,7 @@ def test_default_params_merging(
     """
     request = Request(url="https://example.com")
     request.meta[meta_key] = meta
-    settings = {**SETTINGS, setting_key: setting}
-    crawler = get_crawler(settings)
+    crawler = get_crawler({setting_key: setting})
     handler = get_download_handler(crawler, "https")
     param_parser = handler._param_parser
     with caplog.at_level("WARNING"):
@@ -626,8 +623,7 @@ def test_default_params_immutability(setting_key, meta_key, setting, meta):
     request = Request(url="https://example.com")
     request.meta[meta_key] = meta
     default_params = copy(setting)
-    settings = {**SETTINGS, setting_key: setting}
-    crawler = get_crawler(settings)
+    crawler = get_crawler({setting_key: setting})
     handler = get_download_handler(crawler, "https")
     param_parser = handler._param_parser
     param_parser.parse(request)
@@ -639,7 +635,7 @@ def _test_automap(
 ):
     request = Request(url="https://example.com", **request_kwargs)
     request.meta["zyte_api_automap"] = meta
-    settings = {**SETTINGS, **settings, "ZYTE_API_TRANSPARENT_MODE": True}
+    settings = {**settings, "ZYTE_API_TRANSPARENT_MODE": True}
     crawler = get_crawler(settings)
     if "cookies" in request_kwargs:
         try:
@@ -2149,7 +2145,6 @@ def test_automap_all_cookies(meta):
     Zyte API requests should include all cookie jar cookies, regardless of
     the target URL domain."""
     settings: Dict[str, Any] = {
-        **SETTINGS,
         "ZYTE_API_EXPERIMENTAL_COOKIES_ENABLED": True,
         "ZYTE_API_TRANSPARENT_MODE": True,
     }
@@ -2257,7 +2252,6 @@ def test_automap_cookie_jar(meta):
     )
     request4 = Request(url="https://example.com/4", meta={**meta, "cookiejar": "a"})
     settings: Dict[str, Any] = {
-        **SETTINGS,
         "ZYTE_API_EXPERIMENTAL_COOKIES_ENABLED": True,
         "ZYTE_API_TRANSPARENT_MODE": True,
     }
@@ -2309,7 +2303,6 @@ def test_automap_cookie_jar(meta):
 )
 def test_automap_cookie_limit(meta, caplog):
     settings: Dict[str, Any] = {
-        **SETTINGS,
         "ZYTE_API_EXPERIMENTAL_COOKIES_ENABLED": True,
         "ZYTE_API_MAX_COOKIES": 1,
         "ZYTE_API_TRANSPARENT_MODE": True,
@@ -2439,7 +2432,6 @@ class CustomCookieMiddleware(CookiesMiddleware):
 def test_automap_custom_cookie_middleware():
     mw_cls = CustomCookieMiddleware
     settings = {
-        **SETTINGS,
         "DOWNLOADER_MIDDLEWARES": {
             "scrapy.downloadermiddlewares.cookies.CookiesMiddleware": None,
             f"{mw_cls.__module__}.{mw_cls.__qualname__}": 700,
@@ -2638,7 +2630,6 @@ def test_default_params_automap(default_params, meta, expected, warnings, caplog
     request = Request(url="https://example.com")
     request.meta["zyte_api_automap"] = meta
     settings = {
-        **SETTINGS,
         "ZYTE_API_AUTOMAP_PARAMS": default_params,
         "ZYTE_API_TRANSPARENT_MODE": True,
     }
@@ -2668,7 +2659,6 @@ def test_default_params_false(default_params):
     request = Request(url="https://example.com")
     request.meta["zyte_api_default_params"] = False
     settings = {
-        **SETTINGS,
         "ZYTE_API_DEFAULT_PARAMS": default_params,
     }
     crawler = get_crawler(settings)

--- a/tests/test_request_fingerprinter.py
+++ b/tests/test_request_fingerprinter.py
@@ -27,6 +27,11 @@ def test_cache():
     )
     request = Request("https://example.com", meta={"zyte_api": True})
     fingerprint = fingerprinter.fingerprint(request)
+
+    fingerprinter._param_parser = None  # Prevent later calls from working
+    cached_fingerprint = fingerprinter.fingerprint(request)
+
+    assert fingerprint == cached_fingerprint
     assert fingerprint == fingerprinter._cache[request]
 
 

--- a/tests/test_request_fingerprinter.py
+++ b/tests/test_request_fingerprinter.py
@@ -12,7 +12,7 @@ from scrapy.utils.misc import create_instance
 
 from scrapy_zyte_api import ScrapyZyteAPIRequestFingerprinter
 
-from . import SETTINGS, get_crawler
+from . import get_crawler
 
 
 def test_cache():
@@ -45,7 +45,7 @@ def test_fallback_custom(caplog):
     request = Request("https://example.com", meta={"zyte_api": True})
     assert fingerprinter.fingerprint(request) != b"foo"
     try:
-        import scrapy_poet
+        import scrapy_poet  # noqa: F401
     except ImportError:
         pass
     else:
@@ -56,7 +56,7 @@ def test_fallback_custom(caplog):
 
 
 def test_fallback_default():
-    crawler = get_crawler(SETTINGS)
+    crawler = get_crawler()
     fingerprinter = crawler.request_fingerprinter
     fallback_fingerprinter = (
         crawler.request_fingerprinter._fallback_request_fingerprinter
@@ -223,13 +223,12 @@ def test_only_end_parameters_matter():
     sent to Zyte API are the same."""
 
     settings: Dict[str, Any] = {
-        **SETTINGS,
         "ZYTE_API_TRANSPARENT_MODE": True,
     }
     crawler = get_crawler(settings)
     transparent_fingerprinter = crawler.request_fingerprinter
 
-    crawler = get_crawler(SETTINGS)
+    crawler = get_crawler()
     default_fingerprinter = crawler.request_fingerprinter
 
     request = Request("https://example.com")

--- a/tox.ini
+++ b/tox.ini
@@ -89,7 +89,7 @@ deps =
     # scrapy-poet >= 0.4.0 depends on scrapy >= 2.6.0
     {[testenv:pinned-scrapy-2x6]deps}
     andi==0.6.0
-    scrapy-poet==0.19.0
+    scrapy-poet==0.20.0
     web-poet==0.15.1
     zyte-common-items==0.8.0
 

--- a/tox.ini
+++ b/tox.ini
@@ -89,7 +89,7 @@ deps =
     # scrapy-poet >= 0.4.0 depends on scrapy >= 2.6.0
     {[testenv:pinned-scrapy-2x6]deps}
     andi==0.6.0
-    scrapy-poet==0.20.0
+    scrapy-poet==0.20.1
     web-poet==0.15.1
     zyte-common-items==0.8.0
 


### PR DESCRIPTION
To do:
- [x] Get existing tests to pass.
- [x] Add new tests to cover new scenarios.
  > Make sure the fingerprinter works both for requests that use Zyte API (transparent, automap, raw) as requests that do not, since you could technically request a response any of those ways (instead of using DummyResponse) and use Zyte-API-powered dependency injection on top of it.
- [x] Merge https://github.com/scrapinghub/scrapy-poet/pull/185, release scrapy-poet with it, and update this PR.