### PR TITLE
Cover asking for httpResponseHeaders only in tests

### DIFF
--- a/tests/test_api_requests.py
+++ b/tests/test_api_requests.py
@@ -549,7 +549,7 @@ async def test_default_params_none(mockserver, caplog):
         (
             "ZYTE_API_AUTOMAP_PARAMS",
             "zyte_api_automap",
-            {"httpResponseBody", "httpResponseHeaders"},
+            set(DEFAULT_AUTOMAP_PARAMS),
         ),
     ],
 )
@@ -747,6 +747,18 @@ def _test_automap(
                 "httpResponseBody": True,
                 "httpResponseHeaders": True,
             },
+            [],
+        ),
+        # To request httpResponseHeaders on their own, you must disable
+        # httpResponseBody.
+        (
+            {"httpResponseHeaders": True},
+            {"httpResponseBody": True, "httpResponseHeaders": True},
+            [],
+        ),
+        (
+            {"httpResponseBody": False, "httpResponseHeaders": True},
+            {"httpResponseHeaders": True},
             [],
         ),
     ],


### PR DESCRIPTION
Closes https://github.com/scrapy-plugins/scrapy-zyte-api/issues/57.

I think the current documentation and implementation are fine, so I think it is enough to cover this scenario explicitly in tests.

I thought about doing something more involved, such as making the combination of httpResponseHeaders=True and a non-empty action list prevent httpResponseBody from being enabled automatically, but it feels like adding too much complexity for something that is very rare in practice, and that has an easy workaround (set httpResponseBody=False).