### PR TITLE
adding handling of nested dict for actions

### DIFF
--- a/scrapy_zyte_api/_annotations.py
+++ b/scrapy_zyte_api/_annotations.py
@@ -56,7 +56,17 @@ class _ActionResult(TypedDict, total=False):
     error: Optional[str]
 
 
+def make_hashable(obj):
+    if isinstance(obj, (tuple, list)):
+        return tuple((make_hashable(e) for e in obj))
+
+    if isinstance(obj, dict):
+        return frozenset((make_hashable(k), make_hashable(v)) for k, v in obj.items())
+
+    return obj
+
+
 def actions(value: Iterable[Action]):
     """Convert an iterable of :class:`~scrapy_zyte_api.Action` dicts into a hashable value."""
     # both lists and dicts are not hashable and we need dep types to be hashable
-    return tuple(frozenset(action.items()) for action in value)
+    return tuple(make_hashable(action) for action in value)

--- a/scrapy_zyte_api/providers.py
+++ b/scrapy_zyte_api/providers.py
@@ -119,16 +119,18 @@ class ZyteApiProvider(PageObjectInputProvider):
                         "Actions dependencies must be annotated, "
                         "e.g. Annotated[Actions, actions([...list of actions...])]."
                     )
-                zyte_api_meta["actions"] = [
-                    {
-                        k: (
-                            dict(v)
-                            if isinstance(v, frozenset)
-                            else list(v) if isinstance(v, tuple) else v
-                        )
-                        for k, v in cls.__metadata__[0][0]  # type: ignore[attr-defined]
-                    }
-                ]
+                zyte_api_meta["actions"] = []
+                for action in cls.__metadata__[0]:  # type: ignore[attr-defined]
+                    zyte_api_meta["actions"].append(
+                        {
+                            k: (
+                                dict(v)
+                                if isinstance(v, frozenset)
+                                else list(v) if isinstance(v, tuple) else v
+                            )
+                            for k, v in action
+                        }
+                    )
                 continue
             kw = item_keywords.get(cls_stripped)
             if not kw:

--- a/scrapy_zyte_api/providers.py
+++ b/scrapy_zyte_api/providers.py
@@ -119,11 +119,12 @@ class ZyteApiProvider(PageObjectInputProvider):
                         "Actions dependencies must be annotated, "
                         "e.g. Annotated[Actions, actions([...list of actions...])]."
                     )
-                zyte_api_meta["actions"] = [dict(action) for action in cls.__metadata__[0]]  # type: ignore[attr-defined]
-                for index, item in enumerate(zyte_api_meta["actions"]):
-                    for key in item:
-                        if isinstance(item[key], frozenset):
-                            zyte_api_meta["actions"][index][key] = dict(item[key])
+                zyte_api_meta["actions"] = [
+                    {
+                        k: dict(v) if isinstance(v, frozenset) else v
+                        for k, v in cls.__metadata__[0][0]  # type: ignore[attr-defined]
+                    }
+                ]
                 continue
             kw = item_keywords.get(cls_stripped)
             if not kw:

--- a/scrapy_zyte_api/providers.py
+++ b/scrapy_zyte_api/providers.py
@@ -121,7 +121,11 @@ class ZyteApiProvider(PageObjectInputProvider):
                     )
                 zyte_api_meta["actions"] = [
                     {
-                        k: dict(v) if isinstance(v, frozenset) else v
+                        k: (
+                            dict(v)
+                            if isinstance(v, frozenset)
+                            else list(v) if isinstance(v, tuple) else v
+                        )
                         for k, v in cls.__metadata__[0][0]  # type: ignore[attr-defined]
                     }
                 ]

--- a/scrapy_zyte_api/providers.py
+++ b/scrapy_zyte_api/providers.py
@@ -120,6 +120,10 @@ class ZyteApiProvider(PageObjectInputProvider):
                         "e.g. Annotated[Actions, actions([...list of actions...])]."
                     )
                 zyte_api_meta["actions"] = [dict(action) for action in cls.__metadata__[0]]  # type: ignore[attr-defined]
+                for index, item in enumerate(zyte_api_meta["actions"]):
+                    for key in item:
+                        if isinstance(item[key], frozenset):
+                            zyte_api_meta["actions"][index][key] = dict(item[key])
                 continue
             kw = item_keywords.get(cls_stripped)
             if not kw:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -871,7 +871,18 @@ async def test_provider_actions(mockserver, caplog):
     @attrs.define
     class ActionProductPage(BasePage):
         product: Product
-        actions: Annotated[Actions, actions([{"action": "foo"}, {"action": "bar"}])]
+        actions: Annotated[
+            Actions,
+            actions(
+                [
+                    {
+                        "action": "foo",
+                        "selector": {"type": "css", "value": "button#openDescription"},
+                    },
+                    {"action": "bar"},
+                ]
+            ),
+        ]
 
     class ActionZyteAPISpider(ZyteAPISpider):
         def parse_(self, response: DummyResponse, page: ActionProductPage):  # type: ignore[override]


### PR DESCRIPTION
A possible solution for #187 

- A new function `make_hashable(obj)` was added to convert objects into hashable versions.
- The `actions()` function was updated to use `make_hashable(obj)`.
- A loop was added to iterate over "actions" in `zyte_api_meta`. This allows to convert immutable frozenset objects into mutable dict objects within the "actions" of `zyte_api_meta`.