### PR TITLE
error → debug in log messages before raising exceptions

### DIFF
--- a/scrapy_zyte_api/handler.py
+++ b/scrapy_zyte_api/handler.py
@@ -224,7 +224,7 @@ class _ScrapyZyteAPIBaseDownloadHandler:
             self._process_request_error(request, error)
             raise
         except Exception as er:
-            logger.error(
+            logger.debug(
                 f"Got an error when processing Zyte API request ({request.url}): {er}"
             )
             raise
@@ -235,7 +235,7 @@ class _ScrapyZyteAPIBaseDownloadHandler:
 
     def _process_request_error(self, request, error):
         detail = (error.parsed.data or {}).get("detail", error.message)
-        logger.error(
+        logger.debug(
             f"Got Zyte API error (status={error.status}, "
             f"type={error.parsed.type!r}, request_id={error.request_id!r}) "
             f"while processing URL ({request.url}): {detail}"

--- a/tests/test_api_requests.py
+++ b/tests/test_api_requests.py
@@ -209,6 +209,7 @@ async def test_exceptions(
     exception_text: str,
     mockserver,
 ):
+    caplog.set_level("DEBUG")
     async with mockserver.make_handler() as handler:
         req = Request("http://example.com", method="POST", meta=meta)
         with pytest.raises(exception_type):


### PR DESCRIPTION
Reported by @rahulpatel135.

The messages are useful because they indicate the request URL, which is not part of the original exception, but we do not want to log an error message if the exception is eventually handled, e.g. by a middleware or errback, and if not, the exception itself will trigger an error message.

Note: for `RequestError`, we could eventually include the new `query` parameter in the exception `repr` and remove the log message altogether.