### PR TITLE
Copy known zyte_api_session-prefixed meta into session initialization requests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
     - id: black
 -   repo: https://github.com/pycqa/flake8
-    rev: 7.0.0
+    rev: 7.1.0
     hooks:
     - id: flake8
       additional_dependencies:

--- a/docs/usage/session.rst
+++ b/docs/usage/session.rst
@@ -145,6 +145,13 @@ define a separate :ref:`session config override <session-configs>` for each
 website, each with its own implementation of
 :meth:`~scrapy_zyte_api.SessionConfig.check`.
 
+The :reqmeta:`zyte_api_session_location` and :reqmeta:`zyte_api_session_params`
+request metadata keys, if present in a request that triggers a session
+initialization request, will be copied into the session initialization request,
+so that they are available when :setting:`ZYTE_API_SESSION_CHECKER` or
+:meth:`~scrapy_zyte_api.SessionConfig.check` are called for a session
+initialization request.
+
 If your session checking implementation relies on the response body (e.g. it
 uses CSS or XPath expressions), you should make sure that you are getting one,
 which might not be the case if you are mostly using :ref:`Zyte API automatic

--- a/scrapy_zyte_api/_session.py
+++ b/scrapy_zyte_api/_session.py
@@ -505,6 +505,11 @@ class _SessionManager:
                 SESSION_INIT_META_KEY: True,
                 "dont_merge_cookies": True,
                 "zyte_api": {**session_params, "session": {"id": session_id}},
+                **{
+                    k: v
+                    for k, v in request.meta.items()
+                    if k.startswith("zyte_api_session_")
+                },
             },
             callback=NO_CALLBACK,
         )

--- a/scrapy_zyte_api/_session.py
+++ b/scrapy_zyte_api/_session.py
@@ -508,7 +508,7 @@ class _SessionManager:
                 **{
                     k: v
                     for k, v in request.meta.items()
-                    if k.startswith("zyte_api_session_")
+                    if k in {"zyte_api_session_location", "zyte_api_session_params"}
                 },
             },
             callback=NO_CALLBACK,

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1350,9 +1350,9 @@ async def test_session_config_location_no_set_location(mockserver):
 
 @ensureDeferred
 async def test_session_config_check_meta(mockserver):
-    """When initializing a session, zyte_api_session-prefixed params should be
-    included in the session initialization request, so that they can be used
-    from check methods validating those requests.
+    """When initializing a session, known zyte_api_session-prefixed params
+    should be included in the session initialization request, so that they can
+    be used from check methods validating those requests.
 
     For example, when validating a location, access to
     zyte_api_session_location may be necessary.
@@ -1375,7 +1375,13 @@ async def test_session_config_check_meta(mockserver):
             return (
                 bool(self.location(request))
                 and response.meta["zyte_api_session_params"] == params
-                and response.meta["zyte_api_session_foo"] == "bar"
+                and (
+                    (
+                        response.meta.get("_is_session_init_request", False)
+                        and "zyte_api_session_foo" not in response.meta
+                    )
+                    or response.meta["zyte_api_session_foo"] == "bar"
+                )
             )
 
     settings = {


### PR DESCRIPTION
@VMRuiz reported that, to implement a check method that takes into account meta-defined locations, the init request also needs to have that meta key set. ~I went a bit further and made it so that any `zyte_api_session_`-prefixed meta key is copied into the init request, for extra flexibility.~

To do:
- [x] ~Docs about the meta key copy.~
- [ ] ~Docs about the need, in these scenarios, to create separate pools per location. Or maybe we should provide a default implementation that does so? Maybe even the ability to set a custom pool through meta?~ ([separate PR](https://github.com/scrapy-plugins/scrapy-zyte-api/pull/205#issuecomment-2188283970))