### PR TITLE
Fix The annoyning Deprecation issue in _middlewares.py

### DIFF
--- a/scrapy_zyte_api/_middlewares.py
+++ b/scrapy_zyte_api/_middlewares.py
@@ -31,7 +31,7 @@ class _BaseMiddleware:
             return
 
         downloader = self._crawler.engine.downloader
-        slot_id = downloader._get_slot_key(request, spider)
+        slot_id = downloader.get_slot_key(request)
         if not isinstance(slot_id, str) or not slot_id.startswith(self._slot_prefix):
             slot_id = f"{self._slot_prefix}{slot_id}"
             request.meta["download_slot"] = slot_id

--- a/scrapy_zyte_api/_middlewares.py
+++ b/scrapy_zyte_api/_middlewares.py
@@ -31,7 +31,10 @@ class _BaseMiddleware:
             return
 
         downloader = self._crawler.engine.downloader
-        slot_id = downloader.get_slot_key(request)
+        try:
+            slot_id = downloader.get_slot_key(request)
+        except AttributeError:  # Scrapy < 2.12
+            slot_id = downloader._get_slot_key(request, spider)
         if not isinstance(slot_id, str) or not slot_id.startswith(self._slot_prefix):
             slot_id = f"{self._slot_prefix}{slot_id}"
             request.meta["download_slot"] = slot_id


### PR DESCRIPTION
This pull request includes a change to the `slot_request` method in the `scrapy_zyte_api/_middlewares.py` file. The change involves modifying the way the slot key is obtained from the downloader.

* [`scrapy_zyte_api/_middlewares.py`](diffhunk://#diff-a37eb2a3653a638a1c0bfc3300259feb81b5af120ec49726345f01ebaa233be5L34-R34): Changed the method call from `downloader._get_slot_key(request, spider)` to `downloader.get_slot_key(request)` to use the public method instead of a private one, and hide the warning log

Fixes #232