### PR TITLE
provider: add serp

### DIFF
--- a/docs/reference/inputs.rst
+++ b/docs/reference/inputs.rst
@@ -40,6 +40,8 @@ Inputs
 
 -   :class:`zyte_common_items.ProductNavigation`
 
+-   :class:`zyte_common_items.Serp`
+
 Additional inputs and input annotations are also provided:
 
 Built-in inputs

--- a/scrapy_zyte_api/providers.py
+++ b/scrapy_zyte_api/providers.py
@@ -28,6 +28,7 @@ from zyte_common_items import (
     AutoProductListPage,
     AutoProductNavigationPage,
     AutoProductPage,
+    AutoSerpPage,
     CustomAttributes,
     CustomAttributesMetadata,
     CustomAttributesValues,
@@ -37,6 +38,7 @@ from zyte_common_items import (
     Product,
     ProductList,
     ProductNavigation,
+    Serp,
 )
 from zyte_common_items.fields import is_auto_field
 
@@ -60,6 +62,7 @@ _ITEM_KEYWORDS: Dict[type, str] = {
     ArticleNavigation: "articleNavigation",
     JobPosting: "jobPosting",
     JobPostingNavigation: "jobPostingNavigation",
+    Serp: "serp",
 }
 _AUTO_PAGES: Set[type] = {
     AutoArticlePage,
@@ -70,6 +73,7 @@ _AUTO_PAGES: Set[type] = {
     AutoProductPage,
     AutoProductListPage,
     AutoProductNavigationPage,
+    AutoSerpPage,
 }
 
 
@@ -93,6 +97,7 @@ class ZyteApiProvider(PageObjectInputProvider):
         ProductList,
         ProductNavigation,
         Screenshot,
+        Serp,
     }
 
     def __init__(self, *args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setuptools.setup(
             "andi>=0.6.0",
             "scrapy-poet>=0.22.3",
             "web-poet>=0.17.0",
-            "zyte-common-items>=0.24.0",
+            "zyte-common-items>=0.27.0",
         ]
     },
     classifiers=[

--- a/tox.ini
+++ b/tox.ini
@@ -91,7 +91,7 @@ deps =
     andi==0.6.0
     scrapy-poet==0.22.3
     web-poet==0.17.0
-    zyte-common-items==0.24.0
+    zyte-common-items==0.27.0
 
 [testenv:pinned-extra]
 basepython=python3.9


### PR DESCRIPTION
Subset of https://github.com/scrapy-plugins/scrapy-zyte-api/pull/218 that is a first step towards allowing the `serp` spider from https://github.com/zytedata/zyte-spider-templates to use Serp page objects.