### PR TITLE
Use zero-wait client retry policies in tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -81,6 +81,8 @@ SETTINGS: SETTINGS_T = {
     "TELNETCONSOLE_ENABLED": False,
     "TWISTED_REACTOR": "twisted.internet.asyncioreactor.AsyncioSelectorReactor",
     "ZYTE_API_KEY": _API_KEY,
+    "ZYTE_API_RETRY_POLICY": "tests._retry.POLICY",
+    "ZYTE_API_SESSION_RETRY_POLICY": "tests._retry.SESSION_POLICY",
 }
 if Version(SCRAPY_VERSION) < Version("2.12"):
     SETTINGS["REQUEST_FINGERPRINTER_IMPLEMENTATION"] = (
@@ -117,6 +119,8 @@ SETTINGS_ADDON: SETTINGS_T = {
     },
     "TELNETCONSOLE_ENABLED": False,
     "ZYTE_API_KEY": _API_KEY,
+    "ZYTE_API_RETRY_POLICY": "tests._retry.POLICY",
+    "ZYTE_API_SESSION_RETRY_POLICY": "tests._retry.SESSION_POLICY",
 }
 if _REACTORLESS:
     SETTINGS_ADDON["TWISTED_REACTOR_ENABLED"] = False

--- a/tests/_retry.py
+++ b/tests/_retry.py
@@ -1,0 +1,27 @@
+from tenacity import wait_none
+from zyte_api import RetryFactory
+
+from scrapy_zyte_api._session import SessionRetryFactory
+
+
+class _NoWaitRetryFactory(RetryFactory):
+    """Retry policy that retries as many times as the default one, but without
+    waiting between attempts, so that tests that trigger a retry do not spend
+    minutes sleeping.
+
+    Only the waits whose stop condition is count-based are zeroed. The
+    throttling and network error stop conditions are time-based, so zeroing
+    their waits would turn a retry into a tight loop.
+    """
+
+    download_error_wait = wait_none()  # python-zyte-api >= 0.7.0
+    temporary_download_error_wait = wait_none()  # python-zyte-api < 0.7.0
+    undocumented_error_wait = wait_none()
+
+
+class _NoWaitSessionRetryFactory(_NoWaitRetryFactory, SessionRetryFactory):
+    pass
+
+
+POLICY = _NoWaitRetryFactory().build()
+SESSION_POLICY = _NoWaitSessionRetryFactory().build()

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -259,7 +259,7 @@ assert RETRY_POLICY_A != RETRY_POLICY_B
 @pytest.mark.parametrize(
     ("settings", "meta", "expected"),
     [
-        ({}, {}, None),
+        ({"ZYTE_API_RETRY_POLICY": None}, {}, None),
         (
             {"ZYTE_API_RETRY_POLICY": "tests.test_handler.RETRY_POLICY_A"},
             {},

--- a/tests/test_sessions_errors.py
+++ b/tests/test_sessions_errors.py
@@ -301,7 +301,10 @@ async def test_missing_session_id_on_response(mockserver, caplog):
     ("extra_settings", "expected_policy"),
     [
         # Default: SESSION_DEFAULT_RETRY_POLICY is applied.
-        ({}, "scrapy_zyte_api.SESSION_DEFAULT_RETRY_POLICY"),
+        (
+            {"ZYTE_API_RETRY_POLICY": None, "ZYTE_API_SESSION_RETRY_POLICY": None},
+            "scrapy_zyte_api.SESSION_DEFAULT_RETRY_POLICY",
+        ),
         # Custom ZYTE_API_SESSION_RETRY_POLICY is applied.
         (
             {
@@ -466,6 +469,7 @@ async def test_custom_retry_policy_warning(mockserver, caplog):
         "ZYTE_API_TRANSPARENT_MODE": True,
         "ZYTE_API_URL": mockserver.urljoin("/"),
         "ZYTE_API_RETRY_POLICY": custom_policy,
+        "ZYTE_API_SESSION_RETRY_POLICY": None,
     }
 
     class TestSpider(Spider):


### PR DESCRIPTION
Partial fix for https://github.com/scrapy-plugins/scrapy-zyte-api/issues/235.

```
┌──────────────────────────────────────────┬─────────┬────────┬───────┐
│               Measurement                │ Before  │ After  │ Gain  │
├──────────────────────────────────────────┼─────────┼────────┼───────┤
│ provider full suite, -n auto             │ 97.8 s  │ 50.6 s │ 1.93× │
├──────────────────────────────────────────┼─────────┼────────┼───────┤
│ test_sessions_init_precedence.py, serial │ 364.0 s │ 35.4 s │ 10.3× │
├──────────────────────────────────────────┼─────────┼────────┼───────┤
│ 20-test subset of that file, py313       │ 97.0 s  │ 9.5 s  │ 10.2× │
└──────────────────────────────────────────┴─────────┴────────┴───────┘
```