### PR TITLE
Make ZYTE_API_ENABLED=False disable the add-on too

### DIFF
--- a/scrapy_zyte_api/addon.py
+++ b/scrapy_zyte_api/addon.py
@@ -31,6 +31,9 @@ def _setdefault(settings, setting, cls, pos):
 
 class Addon:
     def update_settings(self, settings: BaseSettings) -> None:
+        if not settings.getbool("ZYTE_API_ENABLED", True):
+            return
+
         from scrapy.settings.default_settings import (  # noqa: PLC0415
             REQUEST_FINGERPRINTER_CLASS as _SCRAPY_DEFAULT_REQUEST_FINGEPRINTER_CLASS,
         )

--- a/tests/test_addon.py
+++ b/tests/test_addon.py
@@ -132,6 +132,21 @@ async def test_addon_fallback_explicit():
     assert isinstance(handler._fallback_handler, DummyDownloadHandler)
 
 
+def test_addon_disabled():
+    base = {
+        "DOWNLOAD_HANDLERS": {
+            "http": "scrapy.core.downloader.handlers.http11.HTTP11DownloadHandler",
+            "https": "scrapy.core.downloader.handlers.http11.HTTP11DownloadHandler",
+        },
+    }
+    settings = Settings({**base, "ZYTE_API_ENABLED": False})
+    Addon().update_settings(settings)
+    assert (
+        settings.copy_to_dict()
+        == Settings({**base, "ZYTE_API_ENABLED": False}).copy_to_dict()
+    )
+
+
 @pytest.mark.skipif(
     not _REACTORLESS_SUPPORT,
     reason="TWISTED_REACTOR_ENABLED requires Scrapy >= 2.15",


### PR DESCRIPTION
Proposed  by @VMRuiz so that, when you set `ZYTE_API_ENABLED=False` to temporarily disable the add-on, you don’t get the download handlers installed anyway.